### PR TITLE
Add support for view collections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astro-loader-pocketbase",
-  "version": "0.2.2",
+  "version": "0.3.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "astro-loader-pocketbase",
-      "version": "0.2.2",
+      "version": "0.3.0-rc.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.11.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "devDependencies": {
         "@eslint/js": "^9.11.1",
         "@stylistic/eslint-plugin": "^2.8.0",
-        "@types/node": "^22.5.5",
-        "astro": "^5.0.0-beta.1",
+        "@types/node": "^22.7.4",
+        "astro": "^5.0.0-beta.2",
         "eslint": "^9.11.1",
         "globals": "^15.9.0",
         "husky": "^9.1.6",
@@ -1069,9 +1069,9 @@
       }
     },
     "node_modules/@oslojs/encoding": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-0.4.1.tgz",
-      "integrity": "sha512-hkjo6MuIK/kQR5CrGNdAPZhS01ZCXuWDRJ187zh6qqF2+yMHZpD9fAYpX8q2bOO6Ryhl3XpCT6kUX76N8hhm4Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+      "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "dev": true
     },
     "node_modules/@rollup/pluginutils": {
@@ -1453,9 +1453,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.5.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.5.tgz",
-      "integrity": "sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==",
+      "version": "22.7.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.4.tgz",
+      "integrity": "sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -1828,17 +1828,17 @@
       }
     },
     "node_modules/astro": {
-      "version": "5.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-5.0.0-beta.1.tgz",
-      "integrity": "sha512-i5L+2tky+cYaLba/UX6KGe4oXGdlYfcPWCukT56FLUWLI4CsXqOL9QC/paUH7qG8jAnxdYnST/HtuyREtiYUhg==",
+      "version": "5.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-5.0.0-beta.2.tgz",
+      "integrity": "sha512-PJlq/pbUwme7PXsFiVCRmrQO3ANh/hnhoQ81vxguwHJOJDwEUOYurJ9JgCJIyMCvRvfOP6G3FKnp3Y640b0B/w==",
       "dev": true,
       "dependencies": {
         "@astrojs/compiler": "^2.10.3",
         "@astrojs/internal-helpers": "0.4.1",
         "@astrojs/markdown-remark": "6.0.0-beta.1",
         "@astrojs/telemetry": "3.1.0",
-        "@babel/types": "^7.25.4",
-        "@oslojs/encoding": "^0.4.1",
+        "@babel/types": "^7.25.6",
+        "@oslojs/encoding": "^1.0.0",
         "@rollup/pluginutils": "^5.1.0",
         "@types/cookie": "^0.6.0",
         "acorn": "^8.12.1",
@@ -1876,7 +1876,6 @@
         "ora": "^8.1.0",
         "p-limit": "^6.1.0",
         "p-queue": "^8.0.1",
-        "path-to-regexp": "6.2.2",
         "preferred-pm": "^4.0.0",
         "prompts": "^2.4.2",
         "rehype": "^13.0.1",
@@ -4725,12 +4724,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/path-to-regexp": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
-      "dev": true
     },
     "node_modules/picocolors": {
       "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astro-loader-pocketbase",
-  "version": "0.3.0-rc.1",
+  "version": "0.3.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "astro-loader-pocketbase",
-      "version": "0.3.0-rc.1",
+      "version": "0.3.0-rc.2",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.11.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astro-loader-pocketbase",
-  "version": "0.3.0-rc.2",
+  "version": "0.3.0-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "astro-loader-pocketbase",
-      "version": "0.3.0-rc.2",
+      "version": "0.3.0-rc.3",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-loader-pocketbase",
-  "version": "0.2.2",
+  "version": "0.3.0-rc.1",
   "description": "A content loader for Astro that uses the PocketBase API",
   "license": "MIT",
   "author": "Luis Wolf <development@pawcode.de> (https://pawcode.de)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-loader-pocketbase",
-  "version": "0.3.0-rc.2",
+  "version": "0.3.0-rc.3",
   "description": "A content loader for Astro that uses the PocketBase API",
   "license": "MIT",
   "author": "Luis Wolf <development@pawcode.de> (https://pawcode.de)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-loader-pocketbase",
-  "version": "0.3.0-rc.1",
+  "version": "0.3.0-rc.2",
   "description": "A content loader for Astro that uses the PocketBase API",
   "license": "MIT",
   "author": "Luis Wolf <development@pawcode.de> (https://pawcode.de)",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "devDependencies": {
     "@eslint/js": "^9.11.1",
     "@stylistic/eslint-plugin": "^2.8.0",
-    "@types/node": "^22.5.5",
-    "astro": "^5.0.0-beta.1",
+    "@types/node": "^22.7.4",
+    "astro": "^5.0.0-beta.2",
     "eslint": "^9.11.1",
     "globals": "^15.9.0",
     "husky": "^9.1.6",

--- a/src/cleanup-entries.ts
+++ b/src/cleanup-entries.ts
@@ -26,7 +26,7 @@ export async function cleanupEntries(
   }
 
   // Prepare pagination variables
-  let page = 1;
+  let page = 0;
   let totalPages = 0;
   const entries = new Set<string>();
 
@@ -34,7 +34,7 @@ export async function cleanupEntries(
   do {
     // Fetch ids from the collection
     const collectionRequest = await fetch(
-      `${collectionUrl}?page=${page}&perPage=1000&fields=id`,
+      `${collectionUrl}?page=${++page}&perPage=1000&fields=id`,
       {
         headers: collectionHeaders
       }

--- a/src/load-entries.ts
+++ b/src/load-entries.ts
@@ -40,7 +40,7 @@ export async function loadEntries(
   );
 
   // Prepare pagination variables
-  let page = 1;
+  let page = 0;
   let totalPages = 0;
   let entries = 0;
   let hasUpdatedColumn = !!lastModified;
@@ -50,7 +50,7 @@ export async function loadEntries(
     // Fetch entries from the collection
     // If `lastModified` is set, only fetch entries that have been modified since the last fetch
     const collectionRequest = await fetch(
-      `${collectionUrl}?page=${page}&perPage=100${
+      `${collectionUrl}?page=${++page}&perPage=100${
         lastModified
           ? `&sort=-updated,id&filter=(updated>"${lastModified}")`
           : ""

--- a/src/load-entries.ts
+++ b/src/load-entries.ts
@@ -43,7 +43,7 @@ export async function loadEntries(
   let page = 1;
   let totalPages = 0;
   let entries = 0;
-  let hasUpdatedColumn = false;
+  let hasUpdatedColumn = !!lastModified;
 
   // Fetch all (modified) entries
   do {

--- a/src/types/pocketbase-entry.type.ts
+++ b/src/types/pocketbase-entry.type.ts
@@ -17,11 +17,11 @@ interface PocketBaseBaseEntry {
   /**
    * Date the entry was created.
    */
-  created: string;
+  created?: string | undefined;
   /**
    * Date the entry was last updated.
    */
-  updated: string;
+  updated?: string | undefined;
 }
 
 /**

--- a/src/types/pocketbase-loader-options.type.ts
+++ b/src/types/pocketbase-loader-options.type.ts
@@ -19,7 +19,7 @@ export interface PocketBaseLoaderOptions {
    * The loader will concatenate the content of all fields in the order they are defined in the array.
    * Each block will be contained in a `<section>` element.
    */
-  content: string | Array<string>;
+  content?: string | Array<string>;
   /**
    * Email of an admin to get full access to the PocketBase instance.
    * Together with `adminPassword` this is required to get automatic type generation and to access all resources even if they are not public.

--- a/src/types/pocketbase-schema.type.ts
+++ b/src/types/pocketbase-schema.type.ts
@@ -40,6 +40,10 @@ export interface PocketBaseCollection {
    */
   name: string;
   /**
+   * Type of the collection.
+   */
+  type: 'base' | 'view' | 'auth';
+  /**
    * Schema of the collection.
    */
   schema: Array<PocketBaseSchemaEntry>;

--- a/src/utils/get-remote-schema.ts
+++ b/src/utils/get-remote-schema.ts
@@ -1,8 +1,5 @@
 import type { PocketBaseLoaderOptions } from "../types/pocketbase-loader-options.type";
-import type {
-  PocketBaseCollection,
-  PocketBaseSchemaEntry
-} from "../types/pocketbase-schema.type";
+import type { PocketBaseCollection } from "../types/pocketbase-schema.type";
 import { getAdminToken } from "./get-admin-token";
 
 /**
@@ -12,7 +9,7 @@ import { getAdminToken } from "./get-admin-token";
  */
 export async function getRemoteSchema(
   options: PocketBaseLoaderOptions
-): Promise<Array<PocketBaseSchemaEntry> | undefined> {
+): Promise<PocketBaseCollection | undefined> {
   if (!options.adminEmail || !options.adminPassword) {
     return undefined;
   }
@@ -52,6 +49,5 @@ export async function getRemoteSchema(
   }
 
   // Get the schema from the response
-  const schema: PocketBaseCollection = await schemaRequest.json();
-  return schema.schema;
+  return await schemaRequest.json();
 }

--- a/src/utils/parse-entry.ts
+++ b/src/utils/parse-entry.ts
@@ -12,7 +12,7 @@ import type { PocketBaseEntry } from "../types/pocketbase-entry.type";
 export async function parseEntry(
   entry: PocketBaseEntry,
   { generateDigest, parseData, store }: LoaderContext,
-  contentFields: string | Array<string>
+  contentFields?: string | Array<string>
 ): Promise<void> {
   // Parse the data to match the schema
   // This will throw an error if the data does not match the schema
@@ -26,6 +26,16 @@ export async function parseEntry(
   // If the entry was never updated, the created date can be used as a fallback.
   // View collections don't necessarily publish the updated date, so the whole entry is used for the digest.
   const digest = generateDigest(entry.updated ?? entry.created ?? entry);
+
+  if (!contentFields) {
+    // Store the entry
+    store.set({
+      id: entry.id,
+      data,
+      digest
+    });
+    return;
+  }
 
   // Generate the content for the entry
   let content: string;

--- a/src/utils/parse-entry.ts
+++ b/src/utils/parse-entry.ts
@@ -1,5 +1,5 @@
 import type { LoaderContext } from "astro/loaders";
-import type { PocketBaseEntry } from "../types/pocketbase-base.type";
+import type { PocketBaseEntry } from "../types/pocketbase-entry.type";
 
 /**
  * Parse an entry from PocketBase to match the schema and store it in the store.
@@ -22,8 +22,10 @@ export async function parseEntry(
   });
 
   // Generate a digest for the entry
-  // We can use the updated data as an identifier if the entry has changed since PocketBase automatically updates this value on every change
-  const digest = generateDigest(entry.updated);
+  // Normal collections use the updated date that is always updated when the entry is updated.
+  // If the entry was never updated, the created date can be used as a fallback.
+  // View collections don't necessarily publish the updated date, so the whole entry is used for the digest.
+  const digest = generateDigest(entry.updated ?? entry.created ?? entry);
 
   // Generate the content for the entry
   let content: string;

--- a/src/utils/parse-schema.ts
+++ b/src/utils/parse-schema.ts
@@ -1,14 +1,17 @@
 import { z } from "astro/zod";
-import type { PocketBaseSchemaEntry } from "../types/pocketbase-schema.type";
+import type {
+  PocketBaseCollection,
+  PocketBaseSchemaEntry
+} from "../types/pocketbase-schema.type";
 
 export function parseSchema(
-  schema: Array<PocketBaseSchemaEntry>
+  collection: PocketBaseCollection
 ): Record<string, z.ZodType> {
   // Prepare the schemas fields
   const fields: Record<string, z.ZodType> = {};
 
   // Parse every field in the schema
-  for (const field of schema) {
+  for (const field of collection.schema) {
     let fieldType;
 
     // Determine the field type and create the corresponding Zod type

--- a/src/utils/parse-schema.ts
+++ b/src/utils/parse-schema.ts
@@ -44,7 +44,8 @@ export function parseSchema(
         break;
       case "relation":
       case "file":
-        // NOTE: Relations and files are currently not supported and are treated as strings
+        // NOTE: Relations are currently not supported and are treated as strings
+        // NOTE: Files are later transformed to URLs
 
         // Parse the field type based on the number of values it can have
         fieldType = parseSingleOrMultipleValues(field, z.string());

--- a/src/utils/read-local-schema.ts
+++ b/src/utils/read-local-schema.ts
@@ -1,9 +1,6 @@
 import fs from "fs/promises";
 import path from "path";
-import type {
-  PocketBaseCollection,
-  PocketBaseSchemaEntry
-} from "../types/pocketbase-schema.type";
+import type { PocketBaseCollection } from "../types/pocketbase-schema.type";
 
 /**
  * Reads the local PocketBase schema file and returns the schema for the specified collection.
@@ -14,7 +11,7 @@ import type {
 export async function readLocalSchema(
   localSchemaPath: string,
   collectionName: string
-): Promise<Array<PocketBaseSchemaEntry> | undefined> {
+): Promise<PocketBaseCollection | undefined> {
   const realPath = path.join(process.cwd(), localSchemaPath);
 
   try {
@@ -38,7 +35,7 @@ export async function readLocalSchema(
       );
     }
 
-    return schema.schema;
+    return schema;
   } catch (error) {
     console.error(
       `Failed to read local schema from ${localSchemaPath}. No types will be generated.\nReason: ${error}`

--- a/src/utils/transform-files.ts
+++ b/src/utils/transform-files.ts
@@ -1,0 +1,66 @@
+import type { PocketBaseEntry } from "../types/pocketbase-entry.type";
+import type { PocketBaseSchemaEntry } from "../types/pocketbase-schema.type";
+
+/**
+ * Transforms file names in a PocketBase entry to file URLs.
+ *
+ * @param baseUrl URL of the PocketBase instance.
+ * @param collection Collection of the entry.
+ * @param entry Entry to transform.
+ */
+export function transformFiles(
+  baseUrl: string,
+  fileFields: Array<PocketBaseSchemaEntry>,
+  entry: PocketBaseEntry
+): PocketBaseEntry {
+  // Transform all file names to file URLs
+  for (const field of fileFields) {
+    const fieldName = field.name;
+
+    if (field.options.maxSelect === 1) {
+      const fileName = entry[fieldName] as string | undefined;
+      // Check if a file name is present
+      if (!fileName) {
+        continue;
+      }
+
+      // Transform the file name to a file URL
+      entry[fieldName] = transformFileUrl(
+        baseUrl,
+        entry.collectionName,
+        entry.id,
+        fileName
+      );
+    } else {
+      const fileNames = entry[fieldName] as Array<string> | undefined;
+      // Check if file names are present
+      if (!fileNames) {
+        continue;
+      }
+
+      // Transform all file names to file URLs
+      entry[fieldName] = fileNames.map((file) =>
+        transformFileUrl(baseUrl, entry.collectionName, entry.id, file)
+      );
+    }
+  }
+
+  return entry;
+}
+
+/**
+ * Transforms a file name to a PocketBase file URL.
+ *
+ * @param base Base URL of the PocketBase instance.
+ * @param collectionName Name of the collection.
+ * @param entryId ID of the entry.
+ * @param file Name of the file.
+ */
+function transformFileUrl(
+  base: string,
+  collectionName: string,
+  entryId: string,
+  file: string
+): string {
+  return `${base}/api/files/${collectionName}/${entryId}/${file}`;
+}


### PR DESCRIPTION
## Issues

- Closes #4 
- Closes #3 

## Changes
- Check type of collection (`base` or `view`) to generate correct types
- Transform values of `file` fields from file name to file URL
- Disable incremental updates for view collections without `updated` column
- Check presence of `updated` column when generating digest
- Force refresh of all entries after version upgrade
- Correctly load paginated entries
- Update dev dependencies