### PR TITLE
fix: make json fields work

### DIFF
--- a/src/utils/parse-schema.ts
+++ b/src/utils/parse-schema.ts
@@ -52,7 +52,7 @@ export function parseSchema(
         break;
       case "json":
         // Parse the field as an object
-        fieldType = z.object({});
+        fieldType = z.unknown();
         break;
       default:
         // Default to a string


### PR DESCRIPTION
I ran into a problem where a json field would return `{}` even though it was set (and returned in api call).
I'm new to Zod but it seems `z.object({})` would only work for empty objects.
Unless there would be a way to supply a custom validator I think `z.unknown` (or `z.any`) is the best we can do.