### PR TITLE
Correctly handle `json` fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If you specify an array of fields, the loader will wrap the content of these fie
 ### Images and files
 
 PocketBase can store images and files for each entry in a collection.
-While the API only returns the filenames of these images and files, the loader will out of the box transform these filenames to the actual URLs of the files.
+While the API only returns the filenames of these images and files, the loader will out of the box **transform these filenames to the actual URLs** of the files.
 This doesn't mean that the files are downloaded during the build process.
 But you can directly use these URLs in your Astro components to display images or link to the files.
 
@@ -109,15 +109,16 @@ This manual schema will **always override the automatic type generation**.
 
 ## All options
 
-| Option           | Type                      | Required | Description                                                                                                                         |
-| ---------------- | ------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `url`            | `string`                  | x        | The URL of your PocketBase instance.                                                                                                |
-| `collectionName` | `string`                  | x        | The name of the collection in your PocketBase instance.                                                                             |
-| `content`        | `string \| Array<string>` |          | The field in the collection to use as content. This can also be an array of fields.                                                 |
-| `adminEmail`     | `string`                  |          | The email of the admin of the PocketBase instance. This is used for automatic type generation and access to private collections.    |
-| `adminPassword`  | `string`                  |          | The password of the admin of the PocketBase instance. This is used for automatic type generation and access to private collections. |
-| `localSchema`    | `string`                  |          | The path to a local schema file. This is used for automatic type generation.                                                        |
-| `forceUpdate`    | `boolean`                 |          | If set to `true`, the loader will fetch every entry instead of only the ones modified since the last build.                         |
+| Option           | Type                          | Required | Description                                                                                                                         |
+| ---------------- | ----------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `url`            | `string`                      | x        | The URL of your PocketBase instance.                                                                                                |
+| `collectionName` | `string`                      | x        | The name of the collection in your PocketBase instance.                                                                             |
+| `content`        | `string \| Array<string>`     |          | The field in the collection to use as content. This can also be an array of fields.                                                 |
+| `adminEmail`     | `string`                      |          | The email of the admin of the PocketBase instance. This is used for automatic type generation and access to private collections.    |
+| `adminPassword`  | `string`                      |          | The password of the admin of the PocketBase instance. This is used for automatic type generation and access to private collections. |
+| `localSchema`    | `string`                      |          | The path to a local schema file. This is used for automatic type generation.                                                        |
+| `jsonSchemas`    | `Record<string, z.ZodSchema>` |          | A record of Zod schemas to use for type generation of `json` fields.                                                                |
+| `forceUpdate`    | `boolean`                     |          | If set to `true`, the loader will fetch every entry instead of only the ones modified since the last build.                         |
 
 ## Special cases
 
@@ -137,3 +138,15 @@ Thus, `view` collections that don't include this field can't be incrementally bu
 
 You can also alias another field as `updated` (as long as it's a date field) in your view.
 While this is possible, it's not recommended since it can lead to outdated data not being fetched.
+
+### JSON fields
+
+PocketBase can store arbitrary JSON data in a `json` field.
+While this data is checked to be valid JSON, there's no schema attached or enforced.
+Theoretically, every entry in a collection can have a different structure in such a field.
+This is why by default the loader will treat these fields as `unknown` and will not generate types for them.
+
+If you have your own schema for these fields, you can provide them via the `jsonSchemas` option.
+The keys of this record should be the field names of your json fields, while the values are Zod schemas.
+This way, the loader will also generate types for these fields and **validate the data against these schemas**.
+So be sure that the schema is correct, up-to-date and all entries in the collection adhere to it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astro-loader-pocketbase",
-  "version": "0.4.0-rc.1",
+  "version": "0.4.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "astro-loader-pocketbase",
-      "version": "0.4.0-rc.1",
+      "version": "0.4.0-rc.2",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.11.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astro-loader-pocketbase",
-  "version": "0.3.0",
+  "version": "0.4.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "astro-loader-pocketbase",
-      "version": "0.3.0",
+      "version": "0.4.0-rc.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-loader-pocketbase",
-  "version": "0.3.0",
+  "version": "0.4.0-rc.1",
   "description": "A content loader for Astro that uses the PocketBase API",
   "license": "MIT",
   "author": "Luis Wolf <development@pawcode.de> (https://pawcode.de)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-loader-pocketbase",
-  "version": "0.4.0-rc.1",
+  "version": "0.4.0-rc.2",
   "description": "A content loader for Astro that uses the PocketBase API",
   "license": "MIT",
   "author": "Luis Wolf <development@pawcode.de> (https://pawcode.de)",

--- a/src/generate-schema.ts
+++ b/src/generate-schema.ts
@@ -63,7 +63,7 @@ export async function generateSchema(
   }
 
   // Parse the schema
-  const fields = parseSchema(collection);
+  const fields = parseSchema(collection, options.jsonSchemas);
 
   // Check if the content field is present
   if (typeof options.content === "string" && !fields[options.content]) {

--- a/src/types/pocketbase-loader-options.type.ts
+++ b/src/types/pocketbase-loader-options.type.ts
@@ -1,3 +1,5 @@
+import type { z } from "astro/zod";
+
 /**
  * Options for the PocketBase loader.
  */
@@ -36,6 +38,14 @@ export interface PocketBaseLoaderOptions {
    * If admin credentials are provided (see `adminEmail` and `adminPassword`), this option will be ignored.
    */
   localSchema?: string;
+  /**
+   * Record of zod schemas for all JSON fields in the collection.
+   * The key must be the name of a field in the collection.
+   * If no schema is provided for a field, the value will be treated as `unknown`.
+   *
+   * Note that this will only be used for fields of type `json`.
+   */
+  jsonSchemas?: Record<string, z.ZodSchema>;
   /**
    * By default, the loader will only fetch entries that have been modified since the last fetch.
    * If you want to fetch all entries, set this to `true`.

--- a/src/utils/parse-schema.ts
+++ b/src/utils/parse-schema.ts
@@ -5,7 +5,8 @@ import type {
 } from "../types/pocketbase-schema.type";
 
 export function parseSchema(
-  collection: PocketBaseCollection
+  collection: PocketBaseCollection,
+  customSchemas: Record<string, z.ZodType> | undefined
 ): Record<string, z.ZodType> {
   // Prepare the schemas fields
   const fields: Record<string, z.ZodType> = {};
@@ -51,8 +52,13 @@ export function parseSchema(
         fieldType = parseSingleOrMultipleValues(field, z.string());
         break;
       case "json":
-        // Parse the field as an object
-        fieldType = z.object({});
+        if (customSchemas && customSchemas[field.name]) {
+          // Use the user defined custom schema for the field
+          fieldType = customSchemas[field.name];
+        } else {
+          // Parse the field as unknown JSON
+          fieldType = z.unknown();
+        }
         break;
       default:
         // Default to a string


### PR DESCRIPTION
### Issues

- Json fields would return empty object
  - Closes #7 

### Changes
- Use `unknown` instead of `object` for json fields, since it otherwise only returns empty objects
- Add `jsonSchemas` option to add custom schema for json fields by users