### PR TITLE
chore(loader): add support for custom unique identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ This manual schema will **always override the automatic type generation**.
 | `content`        | `string \| Array<string>`     |          | The field in the collection to use as content. This can also be an array of fields.                                                 |
 | `adminEmail`     | `string`                      |          | The email of the admin of the PocketBase instance. This is used for automatic type generation and access to private collections.    |
 | `adminPassword`  | `string`                      |          | The password of the admin of the PocketBase instance. This is used for automatic type generation and access to private collections. |
+| `id`  | `string`                      |          | The name of entry field to be used as a unique identifier. Defaults to entry ID. |
 | `localSchema`    | `string`                      |          | The path to a local schema file. This is used for automatic type generation.                                                        |
 | `jsonSchemas`    | `Record<string, z.ZodSchema>` |          | A record of Zod schemas to use for type generation of `json` fields.                                                                |
 | `forceUpdate`    | `boolean`                     |          | If set to `true`, the loader will fetch every entry instead of only the ones modified since the last build.                         |

--- a/src/load-entries.ts
+++ b/src/load-entries.ts
@@ -82,7 +82,7 @@ export async function loadEntries(
 
     // Parse and store the entries
     for (const entry of response.items) {
-      await parseEntry(entry, context, options.content);
+      await parseEntry(entry, context, options.id, options.content);
 
       // Check if the entry has an `updated` column
       // This is used to enable the incremental fetching of entries

--- a/src/types/pocketbase-loader-options.type.ts
+++ b/src/types/pocketbase-loader-options.type.ts
@@ -13,6 +13,13 @@ export interface PocketBaseLoaderOptions {
    */
   collectionName: string;
   /**
+   * ID of the collection in PocketBase.
+   * This is the name of the field that would be used as the ID for the collection.
+   * If not provided, the ID of the entry will be used.
+   * This will be used in getEntry and getEntries to fetch the entry or entries by ID.
+   */
+  id?: string;
+  /**
    * Content of the collection in PocketBase.
    * This must be the name of a field in the collection that contains the content.
    * The content will be parsed as HTML and rendered to the page.

--- a/src/utils/parse-entry.ts
+++ b/src/utils/parse-entry.ts
@@ -6,18 +6,20 @@ import type { PocketBaseEntry } from "../types/pocketbase-entry.type";
  *
  * @param entry Entry to parse.
  * @param context Context of the loader.
+ * @param id ID to use for the entry. If not provided, the ID of the entry will be used.
  * @param contentFields Field(s) to use as content for the entry.
  *                      If multiple fields are used, they will be concatenated and wrapped in `<section>` elements.
  */
 export async function parseEntry(
   entry: PocketBaseEntry,
   { generateDigest, parseData, store }: LoaderContext,
+  id?: string,
   contentFields?: string | Array<string>
 ): Promise<void> {
   // Parse the data to match the schema
   // This will throw an error if the data does not match the schema
   const data = await parseData({
-    id: entry.id,
+    id: entry[id as keyof PocketBaseEntry] as string || entry.id,
     data: entry
   });
 
@@ -30,7 +32,7 @@ export async function parseEntry(
   if (!contentFields) {
     // Store the entry
     store.set({
-      id: entry.id,
+      id: entry[id as keyof PocketBaseEntry] as string || entry.id,
       data,
       digest
     });
@@ -52,7 +54,7 @@ export async function parseEntry(
 
   // Store the entry
   store.set({
-    id: entry.id,
+    id: entry[id as keyof PocketBaseEntry] as string || entry.id,
     data,
     digest,
     rendered: {

--- a/src/utils/parse-entry.ts
+++ b/src/utils/parse-entry.ts
@@ -16,10 +16,13 @@ export async function parseEntry(
   id?: string,
   contentFields?: string | Array<string>
 ): Promise<void> {
+  // Get the custom ID of the entry if it exists
+  const customEntryId = entry[id as keyof PocketBaseEntry] as string | undefined;
+
   // Parse the data to match the schema
   // This will throw an error if the data does not match the schema
   const data = await parseData({
-    id: entry[id as keyof PocketBaseEntry] as string || entry.id,
+    id: customEntryId || entry.id,
     data: entry
   });
 
@@ -32,7 +35,7 @@ export async function parseEntry(
   if (!contentFields) {
     // Store the entry
     store.set({
-      id: entry[id as keyof PocketBaseEntry] as string || entry.id,
+      id: customEntryId || entry.id,
       data,
       digest
     });
@@ -54,7 +57,7 @@ export async function parseEntry(
 
   // Store the entry
   store.set({
-    id: entry[id as keyof PocketBaseEntry] as string || entry.id,
+    id: customEntryId || entry.id,
     data,
     digest,
     rendered: {


### PR DESCRIPTION
This PR implements a feature request outlined in issue #13, introducing support for a custom unique identifier (`slug`) to replace the default Pocketbase ID. This allows for enhanced flexibility by enabling the use of other fields as unique identifiers tailored to specific use cases, including usage with the `getEntry` function.

The proposal introduces a new optional configuration parameter, `id`, which serves as the unique identifier key for collection entries. If `id` is not specified, it defaults to `entry.id`.

Documentation has also been updated to reflect these changes.

### Example Usage

```ts
import { defineCollection } from 'astro:content'
import { pocketbaseLoader } from "astro-loader-pocketbase";

const remotePostsCollection = defineCollection({
  loader: pocketbaseLoader({
    url: <POCKETBASE_URL>,
    adminEmail: <POCKETBASE_ADMIN_EMAIL>,
    adminPassword: <POCKETBASE_ADMIN_PASSWORD>,
    collectionName: "posts",
    content: "content",
    id: "slug",
  }),
})
```

closes #13 