### PR TITLE
Force refresh to update all entries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+env:
+  HUSKY: 0
+
 jobs:
   publish:
     # Use the latest version of Ubuntu

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  HUSKY: 0
+
 jobs:
   test:
     # Use the latest version of Ubuntu

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astro-loader-pocketbase",
-  "version": "2.3.1",
+  "version": "2.4.0-next.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "astro-loader-pocketbase",
-      "version": "2.3.1",
+      "version": "2.4.0-next.1",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-loader-pocketbase",
-  "version": "2.3.1",
+  "version": "2.4.0-next.1",
   "description": "A content loader for Astro that uses the PocketBase API",
   "keywords": [
     "astro",

--- a/src/loader/load-entries.ts
+++ b/src/loader/load-entries.ts
@@ -89,7 +89,11 @@ export async function loadEntries(
   } while (page < totalPages);
 
   // Log the number of fetched entries
-  context.logger.info(
-    `Fetched ${entries}${lastModified ? " changed" : ""} entries.`
-  );
+  if (lastModified) {
+    context.logger.info(
+      `Updated ${entries}/${context.store.keys().length} entries.`
+    );
+  } else {
+    context.logger.info(`Fetched ${entries} entries.`);
+  }
 }

--- a/src/loader/loader.ts
+++ b/src/loader/loader.ts
@@ -18,7 +18,7 @@ export async function loader(
     context.refreshContextData,
     options.collectionName
   );
-  if (!refresh) {
+  if (refresh === "skip") {
     return;
   }
 
@@ -30,6 +30,12 @@ export async function loader(
 
   // Get the date of the last fetch to only update changed entries.
   let lastModified = context.meta.get("last-modified");
+
+  // Force a full update if the refresh is forced
+  if (refresh === "force") {
+    lastModified = undefined;
+    context.store.clear();
+  }
 
   // Check if the version has changed to force an update
   const lastVersion = context.meta.get("version");

--- a/src/utils/should-refresh.ts
+++ b/src/utils/should-refresh.ts
@@ -6,27 +6,32 @@ import type { LoaderContext } from "astro/loaders";
 export function shouldRefresh(
   context: LoaderContext["refreshContextData"],
   collectionName: string
-): boolean {
+): "refresh" | "skip" | "force" {
   // Check if the refresh was triggered by the `astro-integration-pocketbase`
   // and the correct metadata is provided.
-  if (
-    !context ||
-    context.source !== "astro-integration-pocketbase" ||
-    !context.collection
-  ) {
-    return true;
+  if (!context || context.source !== "astro-integration-pocketbase") {
+    return "refresh";
+  }
+
+  // Check if all collections should be refreshed.
+  if (context.force) {
+    return "force";
+  }
+
+  if (!context.collection) {
+    return "refresh";
   }
 
   // Check if the collection name matches the current collection.
   if (typeof context.collection === "string") {
-    return context.collection === collectionName;
+    return context.collection === collectionName ? "refresh" : "skip";
   }
 
   // Check if the collection is included in the list of collections.
   if (Array.isArray(context.collection)) {
-    return context.collection.includes(collectionName);
+    return context.collection.includes(collectionName) ? "refresh" : "skip";
   }
 
   // Should not happen but return true to be safe.
-  return true;
+  return "refresh";
 }

--- a/test/utils/should-refresh.spec.ts
+++ b/test/utils/should-refresh.spec.ts
@@ -1,79 +1,100 @@
-import { assert, describe, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { shouldRefresh } from "../../src/utils/should-refresh";
 
 describe("shouldRefresh", () => {
-  test("should return true if context is undefined", () => {
+  test('should return "refresh" if context is undefined', () => {
     const context = undefined;
     const collectionName = "testCollection";
 
-    assert(shouldRefresh(context, collectionName));
+    expect(shouldRefresh(context, collectionName)).toBe("refresh");
   });
 
-  test("should return true if context source is not 'astro-integration-pocketbase'", () => {
+  test("should return \"refresh\" if context source is not 'astro-integration-pocketbase'", () => {
     const context = {
       source: "other-source",
       collection: "testCollection"
     };
     const collectionName = "testCollection";
 
-    assert(shouldRefresh(context, collectionName));
+    expect(shouldRefresh(context, collectionName)).toBe("refresh");
   });
 
-  test("should return true if context collection is missing", () => {
+  test('should return "refresh" if context collection is missing', () => {
     const context = {
       source: "astro-integration-pocketbase"
     };
     const collectionName = "testCollection";
 
-    assert(shouldRefresh(context, collectionName));
+    expect(shouldRefresh(context, collectionName)).toBe("refresh");
   });
 
-  test("should return true if context collection is a string and matches collectionName", () => {
+  test('should return "refresh" if context collection is a string and matches collectionName', () => {
     const context = {
       source: "astro-integration-pocketbase",
       collection: "testCollection"
     };
     const collectionName = "testCollection";
 
-    assert(shouldRefresh(context, collectionName));
+    expect(shouldRefresh(context, collectionName)).toBe("refresh");
   });
 
-  test("should return false if context collection is a string and does not match collectionName", () => {
+  test('should return "skip" if context collection is a string and does not match collectionName', () => {
     const context = {
       source: "astro-integration-pocketbase",
       collection: "otherCollection"
     };
     const collectionName = "testCollection";
 
-    assert(!shouldRefresh(context, collectionName));
+    expect(shouldRefresh(context, collectionName)).toBe("skip");
   });
 
-  test("should return true if context collection is an array and includes collectionName", () => {
+  test('should return "refresh" if context collection is an array and includes collectionName', () => {
     const context = {
       source: "astro-integration-pocketbase",
       collection: ["testCollection", "otherCollection"]
     };
     const collectionName = "testCollection";
-    assert(shouldRefresh(context, collectionName));
+
+    expect(shouldRefresh(context, collectionName)).toBe("refresh");
   });
 
-  test("should return false if context collection is an array and does not include collectionName", () => {
+  test('should return "skip" if context collection is an array and does not include collectionName', () => {
     const context = {
       source: "astro-integration-pocketbase",
       collection: ["otherCollection"]
     };
     const collectionName = "testCollection";
 
-    assert(!shouldRefresh(context, collectionName));
+    expect(shouldRefresh(context, collectionName)).toBe("skip");
   });
 
-  test("should return true if context collection is an unexpected type", () => {
+  test('should return "refresh" if context collection is an unexpected type', () => {
     const context = {
       source: "astro-integration-pocketbase",
       collection: 123
     };
     const collectionName = "testCollection";
 
-    assert(shouldRefresh(context, collectionName));
+    expect(shouldRefresh(context, collectionName)).toBe("refresh");
+  });
+
+  test('should return "force" if context force is true', () => {
+    const context = {
+      source: "astro-integration-pocketbase",
+      force: true
+    };
+    const collectionName = "testCollection";
+
+    expect(shouldRefresh(context, collectionName)).toBe("force");
+  });
+
+  test('should return "refresh" if context force is false', () => {
+    const context = {
+      source: "astro-integration-pocketbase",
+      force: false
+    };
+    const collectionName = "testCollection";
+
+    expect(shouldRefresh(context, collectionName)).toBe("refresh");
   });
 });


### PR DESCRIPTION
## Changes
- Support `force` flag on refresh context to re-fetch all entries of a collection
- Print total number of entries to simplify debugging after loading

## Is needed for:
- https://github.com/pawcoding/astro-integration-pocketbase/pull/13