### PR TITLE
Add ability for custom filters when fetching entries

### DIFF
--- a/src/loader/load-entries.ts
+++ b/src/loader/load-entries.ts
@@ -50,9 +50,11 @@ export async function loadEntries(
       perPage: "100"
     });
 
-    if (options.filter) {
-      searchQuery.set("filter", options.filter);
-    }
+    // add filter if key exists
+    if (options.filter) searchQuery.set("filter", options.filter);
+
+    // If `lastModified` is set, only fetch entries that have been modified since the last fetch
+    // combine updatedField and custom filter
     if (lastModified && options.updatedField) {
       const customFilter = options.filter ? `&&(${options.filter})` : "";
       searchQuery.set(
@@ -61,9 +63,8 @@ export async function loadEntries(
       );
       searchQuery.set("sort", `-${options.updatedField}`);
     }
-    console.log(`${searchQuery.toString()}`);
+
     // Fetch entries from the collection
-    // If `lastModified` is set, only fetch entries that have been modified since the last fetch
     const collectionRequest = await fetch(
       `${collectionUrl}?${searchQuery.toString()}`,
       {

--- a/src/loader/load-entries.ts
+++ b/src/loader/load-entries.ts
@@ -44,14 +44,28 @@ export async function loadEntries(
 
   // Fetch all (modified) entries
   do {
+    // build search query
+    const searchQuery = new URLSearchParams({
+      page: `${++page}`,
+      perPage: "100"
+    });
+
+    if (options.filter) {
+      searchQuery.set("filter", options.filter);
+    }
+    if (lastModified && options.updatedField) {
+      const customFilter = options.filter ? `&&(${options.filter})` : "";
+      searchQuery.set(
+        "filter",
+        `(${options.updatedField}>"${lastModified}"${customFilter})`
+      );
+      searchQuery.set("sort", `-${options.updatedField}`);
+    }
+    console.log(`${searchQuery.toString()}`);
     // Fetch entries from the collection
     // If `lastModified` is set, only fetch entries that have been modified since the last fetch
     const collectionRequest = await fetch(
-      `${collectionUrl}?page=${++page}&perPage=100${
-        lastModified && options.updatedField
-          ? `&sort=-${options.updatedField},id&filter=(${options.updatedField}>"${lastModified}")`
-          : ""
-      }`,
+      `${collectionUrl}?${searchQuery.toString()}`,
       {
         headers: collectionHeaders
       }

--- a/src/types/pocketbase-loader-options.type.ts
+++ b/src/types/pocketbase-loader-options.type.ts
@@ -73,4 +73,8 @@ export interface PocketBaseLoaderOptions {
    * The PocketBase API does always return at least `0` or `false` as the default values, even though the fields are not marked as required in the schema.
    */
   improveTypes?: boolean;
+  /**
+   *
+   */
+  filter?: string;
 }

--- a/src/types/pocketbase-loader-options.type.ts
+++ b/src/types/pocketbase-loader-options.type.ts
@@ -74,7 +74,10 @@ export interface PocketBaseLoaderOptions {
    */
   improveTypes?: boolean;
   /**
+   * Pass custom filters as string when fetching a collection
+   * Valid syntax can be found on official pocketbase docs https://pocketbase.io/docs/api-collections/#list-collections
    *
+   * Can be used in conjunction with updatedField
    */
   filter?: string;
 }


### PR DESCRIPTION
I've given this an attempt. I added a `filter` field to the loader entry, which is just a string that gets passed down to the pocketbase query. 

I've also added e2e tests, but I'm not quite sure if those tests are up to standards or if I have approached it correctly. 