### PR TITLE
feat(expand): Enables the use of Pocketbases 'Expand' property

### DIFF
--- a/src/loader/load-entries.ts
+++ b/src/loader/load-entries.ts
@@ -66,6 +66,11 @@ export async function loadEntries(
       searchParams.set("filter", filters.join("&&"));
     }
 
+    // Add filters to search parameters
+    if (options.expand) {
+      searchParams.set("expand", options.expand.join(","));
+    }
+
     // Fetch entries from the collection
     const collectionRequest = await fetch(
       `${collectionUrl}?${searchParams.toString()}`,

--- a/src/loader/load-entries.ts
+++ b/src/loader/load-entries.ts
@@ -66,7 +66,7 @@ export async function loadEntries(
       searchParams.set("filter", filters.join("&&"));
     }
 
-    // Add filters to search parameters
+    // Add expand to search parameters
     if (options.expand) {
       searchParams.set("expand", options.expand.join(","));
     }

--- a/src/schema/generate-schema.ts
+++ b/src/schema/generate-schema.ts
@@ -135,7 +135,7 @@ export async function generateSchema(
 
   if (options.expand && options.expand.length > 0) {
     for (const expandedFieldName of options.expand) {
-      const [currentLevelFieldName, deeperExpandFields] =
+      const [currentLevelFieldName, ...deeperExpandFields] =
         getCurrentLevelExpandedFieldName(expandedFieldName);
 
       const expandedFieldDefinition = collection.fields.find(
@@ -157,7 +157,7 @@ export async function generateSchema(
       const expandedSchema = await generateSchema({
         collectionName: expandedFieldDefinition.collectionId,
         superuserCredentials: options.superuserCredentials,
-        expand: [deeperExpandFields],
+        expand: deeperExpandFields.length ? deeperExpandFields : undefined,
         localSchema: options.localSchema,
         jsonSchemas: options.jsonSchemas,
         improveTypes: options.improveTypes,
@@ -222,10 +222,10 @@ export function buildExpandSchema(
   return z.object(shape);
 }
 
-function getCurrentLevelExpandedFieldName(s: string) {
+function getCurrentLevelExpandedFieldName(s: string): Array<string> {
   const fields = s.split(".");
 
-  if (fields.length <= 7) {
+  if (fields.length >= 7) {
     throw new Error(
       `Expand value ${s} exceeds 6 levels of depth that Pocketbase allows`
     );

--- a/src/schema/generate-schema.ts
+++ b/src/schema/generate-schema.ts
@@ -149,7 +149,7 @@ export async function generateSchema(
             `The provided field in the expand property "${expandedFieldName}" does not have an associated collection linked to it, we need this in order to know the shape of the related schema.`
           );
         } else {
-          const expandedchema = await generateSchema({
+          const expandedSchema = await generateSchema({
             collectionName: expandedFieldDefinition.collectionId,
             superuserCredentials: options.superuserCredentials,
             localSchema: options.localSchema,
@@ -201,7 +201,7 @@ export async function generateSchema(
  * Builds a Zod object schema from expandedFields, where each property is either a ZodSchema or an array of ZodSchema.
  */
 export function buildExpandSchema(
-  expandedFields: Record<string, ZodSchema | Array<ZodSchema>>
+  expandedFields: ExpandedFields
 ): ZodObject<Record<string, ZodSchema | z.ZodArray<ZodSchema>>> {
   const shape: Record<string, ZodSchema | z.ZodArray<ZodSchema>> = {};
 

--- a/src/schema/generate-schema.ts
+++ b/src/schema/generate-schema.ts
@@ -6,7 +6,7 @@ import type {
 } from "../types/pocketbase-collection.type";
 import type { PocketBaseLoaderOptions } from "../types/pocketbase-loader-options.type";
 import { getRemoteSchema } from "./get-remote-schema";
-import { parseSchema } from "./parse-schema";
+import { parseExpandedSchemaField, parseSchema } from "./parse-schema";
 import { readLocalSchema } from "./read-local-schema";
 import { transformFiles } from "./transform-files";
 
@@ -154,6 +154,8 @@ export async function generateSchema(
         );
       }
 
+      const isRequired = expandedFieldDefinition.required;
+
       const expandedSchema = await generateSchema({
         collectionName: expandedFieldDefinition.collectionId,
         superuserCredentials: options.superuserCredentials,
@@ -164,10 +166,10 @@ export async function generateSchema(
         url: options.url
       });
 
-      expandedFields[expandedFieldName] = z.union([
-        expandedSchema,
-        z.array(expandedSchema)
-      ]);
+      expandedFields[expandedFieldName] = parseExpandedSchemaField(
+        expandedFieldDefinition,
+        expandedSchema
+      );
     }
   }
 

--- a/src/schema/generate-schema.ts
+++ b/src/schema/generate-schema.ts
@@ -133,7 +133,7 @@ export async function generateSchema(
     }
   }
 
-  if (options.expand) {
+  if (options.expand && options.expand.length > 0) {
     for (const expandedFieldName of options.expand) {
       const [currentLevelFieldName, deeperExpandFields] =
         getCurrentLevelExpandedFieldName(expandedFieldName);

--- a/src/schema/parse-schema.ts
+++ b/src/schema/parse-schema.ts
@@ -1,8 +1,6 @@
 import { z } from "astro/zod";
-import type {
-  PocketBaseCollection,
-  PocketBaseSchemaEntry
-} from "../types/pocketbase-schema.type";
+import type { PocketBaseCollection } from "../types/pocketbase-collection.type";
+import type { PocketBaseSchemaEntry } from "../types/pocketbase-schema.type";
 
 export function parseSchema(
   collection: PocketBaseCollection,

--- a/src/schema/read-local-schema.ts
+++ b/src/schema/read-local-schema.ts
@@ -1,6 +1,6 @@
 import fs from "fs/promises";
 import path from "path";
-import type { PocketBaseCollection } from "../types/pocketbase-schema.type";
+import type { PocketBaseCollection } from "../types/pocketbase-collection.type";
 
 /**
  * Reads the local PocketBase schema file and returns the schema for the specified collection.

--- a/src/types/pocketbase-collection.type.ts
+++ b/src/types/pocketbase-collection.type.ts
@@ -1,10 +1,9 @@
-import type { ZodSchema } from "astro/zod";
 import type { PocketBaseSchemaEntry } from "./pocketbase-schema.type";
 
 /**
- * Base interface for all PocketBase entries.
+ * Base interface for all PocketBase collections.
  */
-interface PocketBaseBaseCollection {
+export interface PocketBaseCollection {
   /**
    * ID of the collection.
    */
@@ -22,11 +21,3 @@ interface PocketBaseBaseCollection {
    */
   fields: Array<PocketBaseSchemaEntry>;
 }
-
-/**
- * Type for a PocketBase entry.
- */
-export type PocketBaseCollection = PocketBaseBaseCollection &
-  Record<string, unknown>;
-
-export type ExpandedFields = Record<string, ZodSchema | Array<ZodSchema>>;

--- a/src/types/pocketbase-collection.type.ts
+++ b/src/types/pocketbase-collection.type.ts
@@ -1,0 +1,32 @@
+import type { ZodSchema } from "astro/zod";
+import type { PocketBaseSchemaEntry } from "./pocketbase-schema.type";
+
+/**
+ * Base interface for all PocketBase entries.
+ */
+interface PocketBaseBaseCollection {
+  /**
+   * ID of the collection.
+   */
+  id: string;
+  /**
+   * Name of the collection
+   */
+  name: string;
+  /**
+   * Type of the collection.
+   */
+  type: "base" | "view" | "auth";
+  /**
+   * Schema of the collection.
+   */
+  fields: Array<PocketBaseSchemaEntry>;
+}
+
+/**
+ * Type for a PocketBase entry.
+ */
+export type PocketBaseCollection = PocketBaseBaseCollection &
+  Record<string, unknown>;
+
+export type ExpandedFields = Record<string, ZodSchema | Array<ZodSchema>>;

--- a/src/types/pocketbase-entry.type.ts
+++ b/src/types/pocketbase-entry.type.ts
@@ -17,7 +17,7 @@ interface PocketBaseBaseEntry {
   /**
    * Optional property that contains all relational fields that have been expanded to contain their linked entry(s)
    */
-  expand?: Record<string, PocketBaseBaseEntry & Record<string, unknown>>;
+  expand?: Record<string, PocketBaseEntry>;
 }
 
 /**

--- a/src/types/pocketbase-entry.type.ts
+++ b/src/types/pocketbase-entry.type.ts
@@ -14,6 +14,10 @@ interface PocketBaseBaseEntry {
    * Name of the collection the entry belongs to.
    */
   collectionName: string;
+  /**
+   * Optional property that contains all relational fields that have been expanded to contain their linked entry(s)
+   */
+  expand?: Record<string, PocketBaseBaseEntry & Record<string, unknown>>;
 }
 
 /**

--- a/src/types/pocketbase-entry.type.ts
+++ b/src/types/pocketbase-entry.type.ts
@@ -17,7 +17,7 @@ interface PocketBaseBaseEntry {
   /**
    * Optional property that contains all relational fields that have been expanded to contain their linked entry(s)
    */
-  expand?: Record<string, PocketBaseEntry>;
+  expand?: Record<string, PocketBaseEntry | Array<PocketBaseEntry | null>>;
 }
 
 /**

--- a/src/types/pocketbase-loader-options.type.ts
+++ b/src/types/pocketbase-loader-options.type.ts
@@ -55,6 +55,19 @@ export interface PocketBaseLoaderOptions {
    */
   filter?: string;
   /**
+   * array of relational field names to auto expand when loading data from PocketBase.
+   * Valid syntax can be found in the [PocketBase documentation](https://pocketbase.io/docs/api-records/#listsearch-records)
+   * Example:
+   * ```ts
+   * // config:
+   * expand: ['relatedField1', 'relatedField2']
+   *
+   * // request
+   * `?expand=relatedField1,relatedField2`
+   * ```
+   */
+  expand?: Array<string>;
+  /**
    * Credentials of a superuser to get full access to the PocketBase instance.
    * This is required to get automatic type generation without a local schema, to access all resources even if they are not public and to fetch content of hidden fields.
    */

--- a/src/types/pocketbase-schema.type.ts
+++ b/src/types/pocketbase-schema.type.ts
@@ -39,22 +39,10 @@ export interface PocketBaseSchemaEntry {
    * This is only present on "autodate" fields.
    */
   onUpdate?: boolean;
-}
 
-/**
- * Schema for a PocketBase collection.
- */
-export interface PocketBaseCollection {
   /**
-   * Name of the collection.
+   * The associated collection id that the relation field is referencing
+   * This is only present on "relation"fields.
    */
-  name: string;
-  /**
-   * Type of the collection.
-   */
-  type: "base" | "view" | "auth";
-  /**
-   * Schema of the collection.
-   */
-  fields: Array<PocketBaseSchemaEntry>;
+  collectionId?: string;
 }

--- a/src/types/pocketbase-schema.type.ts
+++ b/src/types/pocketbase-schema.type.ts
@@ -42,7 +42,7 @@ export interface PocketBaseSchemaEntry {
 
   /**
    * The associated collection id that the relation field is referencing
-   * This is only present on "relation"fields.
+   * This is only present on "relation" fields.
    */
   collectionId?: string;
 }

--- a/test/_mocks/insert-collection.ts
+++ b/test/_mocks/insert-collection.ts
@@ -1,11 +1,12 @@
 import { assert } from "console";
+import type { PocketBaseCollection } from "../../src/types/pocketbase-collection.type";
 import type { PocketBaseLoaderOptions } from "../../src/types/pocketbase-loader-options.type";
 
 export async function insertCollection(
   fields: Array<Record<string, unknown>>,
   options: PocketBaseLoaderOptions,
   superuserToken: string
-): Promise<void> {
+): Promise<PocketBaseCollection> {
   const insertRequest = await fetch(new URL(`api/collections`, options.url), {
     method: "POST",
     headers: {
@@ -19,4 +20,9 @@ export async function insertCollection(
   });
 
   assert(insertRequest.status === 200, "Collection is not available.");
+
+  const collection = await insertRequest.json();
+  assert(collection.id, "Collection ID is not available.");
+
+  return collection;
 }

--- a/test/loader/load-entries.e2e-spec.ts
+++ b/test/loader/load-entries.e2e-spec.ts
@@ -166,8 +166,6 @@ describe("loadEntries", () => {
       superuserToken
     );
 
-    const parsedEntries: Array<PocketBaseEntry> = [];
-
     const blueEntry = await insertEntry(
       { name: BLUE_ENTRY_NAME_FIELD_VALUE },
       blueCollectionOptions,
@@ -183,7 +181,6 @@ describe("loadEntries", () => {
     await loadEntries(testOptions, context, superuserToken, undefined);
 
     const entryFromCall = parsedEntrySpy!.mock.calls[0][0];
-
     const relatedEntry = entryFromCall.expand?.related as PocketBaseEntry;
 
     // Ensure expand and related exist and are of expected type

--- a/test/loader/load-entries.e2e-spec.ts
+++ b/test/loader/load-entries.e2e-spec.ts
@@ -185,7 +185,7 @@ describe("loadEntries", () => {
 
     await loadEntries(testOptions, context, superuserToken, undefined);
 
-    expect(parsedEntries[0]?.expand?.related?.name).toBe(
+    expect(parsedEntries[0]?.expand?.related.name).toBe(
       BLUE_ENTRY_NAME_FIELD_VALUE
     );
 

--- a/test/schema/generate-schema.e2e-spec.ts
+++ b/test/schema/generate-schema.e2e-spec.ts
@@ -312,8 +312,8 @@ describe("generateSchema", () => {
         console.log(error);
       }
 
-      deleteCollection(redCollectionOptions, superuserToken);
-      deleteCollection(blueCollectionOptions, superuserToken);
+      await deleteCollection(redCollectionOptions, superuserToken);
+      await deleteCollection(blueCollectionOptions, superuserToken);
     });
   });
 });

--- a/test/schema/generate-schema.e2e-spec.ts
+++ b/test/schema/generate-schema.e2e-spec.ts
@@ -1,15 +1,44 @@
+import type { LoaderContext } from "astro/loaders";
 import type { ZodObject, ZodSchema } from "astro/zod";
-import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "crypto";
+import {
+  afterEach,
+  assert,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi
+} from "vitest";
 import { generateSchema } from "../../src/schema/generate-schema";
 import { transformFileUrl } from "../../src/schema/transform-files";
+import { getSuperuserToken } from "../../src/utils/get-superuser-token";
 import { checkE2eConnection } from "../_mocks/check-e2e-connection";
+import { createLoaderContext } from "../_mocks/create-loader-context";
 import { createLoaderOptions } from "../_mocks/create-loader-options";
+import { deleteCollection } from "../_mocks/delete-collection";
+import { insertCollection } from "../_mocks/insert-collection";
 
 describe("generateSchema", () => {
   const options = createLoaderOptions({ collectionName: "_superusers" });
+  let context: LoaderContext;
+  let superuserToken: string;
 
   beforeAll(async () => {
     await checkE2eConnection();
+  });
+
+  beforeEach(async () => {
+    context = createLoaderContext();
+
+    const token = await getSuperuserToken(
+      options.url,
+      options.superuserCredentials!
+    );
+
+    assert(token, "Superuser token is not available.");
+    superuserToken = token;
   });
 
   afterEach(() => {
@@ -44,7 +73,8 @@ describe("generateSchema", () => {
         "emailVisibility",
         "verified",
         "created",
-        "updated"
+        "updated",
+        "expand"
       ]);
     });
 
@@ -63,7 +93,8 @@ describe("generateSchema", () => {
         "emailVisibility",
         "verified",
         "created",
-        "updated"
+        "updated",
+        "expand"
       ]);
     });
   });
@@ -197,6 +228,92 @@ describe("generateSchema", () => {
         entry.id,
         entry.avatar
       )
+    });
+  });
+
+  describe("expand field", async () => {
+    it("the related fields schema is provided for expanded fields", async () => {
+      const RELATION_FIELD_NAME = "related";
+
+      const redCollectionOptions = {
+        ...options,
+        collectionName: `red_${randomUUID().replace(/-/g, "")}`
+      };
+
+      const blueCollectionOptions = {
+        ...options,
+        collectionName: `blue_${randomUUID().replace(/-/g, "")}`
+      };
+
+      const blueCollection = await insertCollection(
+        [
+          {
+            name: "name",
+            type: "text"
+          }
+        ],
+        blueCollectionOptions,
+        superuserToken
+      );
+
+      await insertCollection(
+        [
+          {
+            name: RELATION_FIELD_NAME,
+            type: "relation",
+            collectionId: blueCollection.id
+          }
+        ],
+        redCollectionOptions,
+        superuserToken
+      );
+
+      try {
+        const testOptions = {
+          ...options,
+          collectionName: redCollectionOptions.collectionName,
+          expand: [RELATION_FIELD_NAME]
+        };
+        const schema = (await generateSchema(testOptions)) as ZodObject<
+          Record<string, ZodSchema<unknown>>
+        >;
+
+        const expandSchema = schema.shape.expand;
+        const validExpand = {
+          related: {
+            collectionId: blueCollection.id,
+            collectionName: blueCollection.name,
+            id: "test",
+            name: "Blue Entry"
+          }
+        };
+
+        expect(() => expandSchema.parse(validExpand)).not.toThrow();
+
+        const validArrayExpand = {
+          related: [
+            {
+              collectionId: blueCollection.id,
+              collectionName: blueCollection.name,
+              id: "test",
+              name: "Blue Entry"
+            },
+            {
+              collectionId: blueCollection.id,
+              collectionName: blueCollection.name,
+              id: "test",
+              name: "Blue Entry"
+            }
+          ]
+        };
+
+        expect(() => expandSchema.parse(validArrayExpand)).not.toThrow();
+      } catch (error) {
+        console.log(error);
+      }
+
+      deleteCollection(redCollectionOptions, superuserToken);
+      deleteCollection(blueCollectionOptions, superuserToken);
     });
   });
 });

--- a/test/schema/generate-schema.e2e-spec.ts
+++ b/test/schema/generate-schema.e2e-spec.ts
@@ -261,7 +261,8 @@ describe("generateSchema", () => {
           {
             name: RELATION_FIELD_NAME,
             type: "relation",
-            collectionId: blueCollection.id
+            collectionId: blueCollection.id,
+            maxSelect: 999
           }
         ],
         redCollectionOptions,
@@ -278,16 +279,6 @@ describe("generateSchema", () => {
       >;
 
       const expandSchema = schema.shape.expand;
-      const validExpand = {
-        related: {
-          collectionId: blueCollection.id,
-          collectionName: blueCollection.name,
-          id: "test",
-          name: "Blue Entry"
-        }
-      };
-
-      expect(() => expandSchema.parse(validExpand)).not.toThrow();
 
       const validArrayExpand = {
         related: [

--- a/test/schema/generate-schema.e2e-spec.ts
+++ b/test/schema/generate-schema.e2e-spec.ts
@@ -268,49 +268,45 @@ describe("generateSchema", () => {
         superuserToken
       );
 
-      try {
-        const testOptions = {
-          ...options,
-          collectionName: redCollectionOptions.collectionName,
-          expand: [RELATION_FIELD_NAME]
-        };
-        const schema = (await generateSchema(testOptions)) as ZodObject<
-          Record<string, ZodSchema<unknown>>
-        >;
+      const testOptions = {
+        ...options,
+        collectionName: redCollectionOptions.collectionName,
+        expand: [RELATION_FIELD_NAME]
+      };
+      const schema = (await generateSchema(testOptions)) as ZodObject<
+        Record<string, ZodSchema<unknown>>
+      >;
 
-        const expandSchema = schema.shape.expand;
-        const validExpand = {
-          related: {
+      const expandSchema = schema.shape.expand;
+      const validExpand = {
+        related: {
+          collectionId: blueCollection.id,
+          collectionName: blueCollection.name,
+          id: "test",
+          name: "Blue Entry"
+        }
+      };
+
+      expect(() => expandSchema.parse(validExpand)).not.toThrow();
+
+      const validArrayExpand = {
+        related: [
+          {
+            collectionId: blueCollection.id,
+            collectionName: blueCollection.name,
+            id: "test",
+            name: "Blue Entry"
+          },
+          {
             collectionId: blueCollection.id,
             collectionName: blueCollection.name,
             id: "test",
             name: "Blue Entry"
           }
-        };
+        ]
+      };
 
-        expect(() => expandSchema.parse(validExpand)).not.toThrow();
-
-        const validArrayExpand = {
-          related: [
-            {
-              collectionId: blueCollection.id,
-              collectionName: blueCollection.name,
-              id: "test",
-              name: "Blue Entry"
-            },
-            {
-              collectionId: blueCollection.id,
-              collectionName: blueCollection.name,
-              id: "test",
-              name: "Blue Entry"
-            }
-          ]
-        };
-
-        expect(() => expandSchema.parse(validArrayExpand)).not.toThrow();
-      } catch (error) {
-        console.log(error);
-      }
+      expect(() => expandSchema.parse(validArrayExpand)).not.toThrow();
 
       await deleteCollection(redCollectionOptions, superuserToken);
       await deleteCollection(blueCollectionOptions, superuserToken);

--- a/test/schema/parse-schema.spec.ts
+++ b/test/schema/parse-schema.spec.ts
@@ -1,12 +1,13 @@
 import { z } from "astro/zod";
 import { describe, expect, test } from "vitest";
 import { parseSchema } from "../../src/schema/parse-schema";
-import type { PocketBaseCollection } from "../../src/types/pocketbase-schema.type";
+import type { PocketBaseCollection } from "../../src/types/pocketbase-collection.type";
 
 describe("parseSchema", () => {
   describe("number", () => {
     test("should parse number fields correctly", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "numberCollection",
         type: "base",
         fields: [{ name: "age", type: "number", required: true, hidden: false }]
@@ -25,6 +26,7 @@ describe("parseSchema", () => {
 
     test("should parse optional number fields correctly", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "numberCollection",
         type: "base",
         fields: [
@@ -44,6 +46,7 @@ describe("parseSchema", () => {
 
     test("should parse optional number fields correctly with improved types", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "numberCollection",
         type: "base",
         fields: [
@@ -65,6 +68,7 @@ describe("parseSchema", () => {
   describe("boolean", () => {
     test("should parse boolean fields correctly", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "booleanCollection",
         type: "base",
         fields: [
@@ -85,6 +89,7 @@ describe("parseSchema", () => {
 
     test("should parse optional boolean fields correctly", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "booleanCollection",
         type: "base",
         fields: [
@@ -104,6 +109,7 @@ describe("parseSchema", () => {
 
     test("should parse optional boolean fields correctly with improved types", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "booleanCollection",
         type: "base",
         fields: [
@@ -125,6 +131,7 @@ describe("parseSchema", () => {
   describe("date", () => {
     test("should parse date fields correctly", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "dateCollection",
         type: "base",
         fields: [
@@ -147,6 +154,7 @@ describe("parseSchema", () => {
 
     test("should parse optional date fields correctly", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "dateCollection",
         type: "base",
         fields: [
@@ -168,6 +176,7 @@ describe("parseSchema", () => {
   describe("autodate", () => {
     test("should parse autodate fields correctly", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "dateCollection",
         type: "base",
         fields: [
@@ -195,6 +204,7 @@ describe("parseSchema", () => {
 
     test("should parse optional autodate fields correctly", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "dateCollection",
         type: "base",
         fields: [
@@ -219,6 +229,7 @@ describe("parseSchema", () => {
 
     test("should parse autodate fields with onCreate correctly", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "dateCollection",
         type: "base",
         fields: [
@@ -246,6 +257,7 @@ describe("parseSchema", () => {
   describe("geoPoint", () => {
     test("should parse geoPoint fields correctly", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "geoPointCollection",
         type: "base",
         fields: [
@@ -274,6 +286,7 @@ describe("parseSchema", () => {
 
     test("should parse optional geoPoint fields correctly", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "geoPointCollection",
         type: "base",
         fields: [
@@ -300,6 +313,7 @@ describe("parseSchema", () => {
   describe("select", () => {
     test("should parse select fields correctly", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "selectCollection",
         type: "base",
         fields: [
@@ -326,6 +340,7 @@ describe("parseSchema", () => {
 
     test("should throw an error if no values are defined", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "selectCollection",
         type: "base",
         fields: [
@@ -343,6 +358,7 @@ describe("parseSchema", () => {
 
     test("should parse select fields with multiple values correctly", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "selectCollection",
         type: "base",
         fields: [
@@ -372,6 +388,7 @@ describe("parseSchema", () => {
 
     test("should parse optional select fields correctly", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "selectCollection",
         type: "base",
         fields: [
@@ -400,6 +417,7 @@ describe("parseSchema", () => {
   describe("relation", () => {
     test("should parse relation fields correctly", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "relationCollection",
         type: "base",
         fields: [
@@ -425,6 +443,7 @@ describe("parseSchema", () => {
 
     test("should parse relation fields with multiple values correctly", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "relationCollection",
         type: "base",
         fields: [
@@ -451,6 +470,7 @@ describe("parseSchema", () => {
 
     test("should parse optional relation fields correctly", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "relationCollection",
         type: "base",
         fields: [
@@ -478,6 +498,7 @@ describe("parseSchema", () => {
   describe("file", () => {
     test("should parse file fields correctly", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "fileCollection",
         type: "base",
         fields: [
@@ -503,6 +524,7 @@ describe("parseSchema", () => {
 
     test("should parse file fields with multiple values correctly", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "fileCollection",
         type: "base",
         fields: [
@@ -536,6 +558,7 @@ describe("parseSchema", () => {
 
     test("should parse optional file fields correctly", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "fileCollection",
         type: "base",
         fields: [
@@ -563,6 +586,7 @@ describe("parseSchema", () => {
   describe("json", () => {
     test("should parse json fields with custom schema correctly", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "jsonCollection",
         type: "base",
         fields: [
@@ -601,6 +625,7 @@ describe("parseSchema", () => {
 
     test("should parse json fields without custom schema correctly", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "jsonCollection",
         type: "base",
         fields: [
@@ -631,6 +656,7 @@ describe("parseSchema", () => {
 
     test("should parse optional json fields correctly", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "jsonCollection",
         type: "base",
         fields: [
@@ -660,6 +686,7 @@ describe("parseSchema", () => {
   describe("text", () => {
     test("should parse text fields correctly", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "stringCollection",
         type: "base",
         fields: [{ name: "name", type: "text", required: true, hidden: false }]
@@ -678,6 +705,7 @@ describe("parseSchema", () => {
 
     test("should parse optional text fields correctly", () => {
       const collection: PocketBaseCollection = {
+        id: "0",
         name: "stringCollection",
         type: "base",
         fields: [{ name: "name", type: "text", required: false, hidden: false }]


### PR DESCRIPTION
Pocketbase has a useful way to automatically expand relation fields with their data, this PR explores enabled the pocketbase-loader to do the same, this has to be implemented on both schema generation and fetching of the actual data. 

At present I am only allowing one level deep, however it would not be terribly complex to allow deeper chaining but there would still need to be a cut off point. 

Also one decision I made whilst doing this was to preserve the way Pocketbase returns expanded fields in their own object. However I am wondering if for a more streamlined experience, we should expand the values directly in their original field.