### PR TITLE
Use single superuser token

### DIFF
--- a/src/loader/loader.ts
+++ b/src/loader/loader.ts
@@ -1,15 +1,18 @@
 import type { LoaderContext } from "astro/loaders";
 import packageJson from "../../package.json";
 import type { PocketBaseLoaderOptions } from "../types/pocketbase-loader-options.type";
-import { getSuperuserToken } from "../utils/get-superuser-token";
 import { shouldRefresh } from "../utils/should-refresh";
 import { cleanupEntries } from "./cleanup-entries";
 import { handleRealtimeUpdates } from "./handle-realtime-updates";
 import { loadEntries } from "./load-entries";
 
+/**
+ * Load entries from a PocketBase collection.
+ */
 export async function loader(
   context: LoaderContext,
-  options: PocketBaseLoaderOptions
+  options: PocketBaseLoaderOptions,
+  token: string | undefined
 ): Promise<void> {
   context.logger.label = `pocketbase-loader:${options.collectionName}`;
 
@@ -57,16 +60,6 @@ export async function loader(
       `No "updatedField" was provided. Incremental builds are disabled.`
     );
     lastModified = undefined;
-  }
-
-  // Try to get a superuser token to access all resources.
-  let token: string | undefined;
-  if (options.superuserCredentials) {
-    token = await getSuperuserToken(
-      options.url,
-      options.superuserCredentials,
-      context.logger
-    );
   }
 
   if (context.store.keys().length > 0) {

--- a/src/schema/generate-schema.ts
+++ b/src/schema/generate-schema.ts
@@ -28,14 +28,18 @@ const VALID_ID_TYPES = ["text", "number", "email", "url", "date"];
  * If a path to a local schema file is provided, the schema is read from the file.
  *
  * @param options Options for the loader. See {@link PocketBaseLoaderOptions} for more details.
+ * @param token The superuser token to authenticate the request.
  */
 export async function generateSchema(
-  options: PocketBaseLoaderOptions
+  options: PocketBaseLoaderOptions,
+  token: string | undefined
 ): Promise<ZodSchema> {
   let collection: PocketBaseCollection | undefined;
 
-  // Try to get the schema directly from the PocketBase instance
-  collection = await getRemoteSchema(options);
+  if (token) {
+    // Try to get the schema directly from the PocketBase instance
+    collection = await getRemoteSchema(options, token);
+  }
 
   const hasSuperuserRights = !!collection || !!options.superuserCredentials;
 

--- a/src/schema/get-remote-schema.ts
+++ b/src/schema/get-remote-schema.ts
@@ -1,30 +1,16 @@
 import type { PocketBaseLoaderOptions } from "../types/pocketbase-loader-options.type";
 import type { PocketBaseCollection } from "../types/pocketbase-schema.type";
-import { getSuperuserToken } from "../utils/get-superuser-token";
 
 /**
  * Fetches the schema for the specified collection from the PocketBase instance.
  *
  * @param options Options for the loader. See {@link PocketBaseLoaderOptions} for more details.
+ * @param token The superuser token to authenticate the request.
  */
 export async function getRemoteSchema(
-  options: PocketBaseLoaderOptions
+  options: PocketBaseLoaderOptions,
+  token: string
 ): Promise<PocketBaseCollection | undefined> {
-  if (!options.superuserCredentials) {
-    return undefined;
-  }
-
-  // Get a superuser token
-  const token = await getSuperuserToken(
-    options.url,
-    options.superuserCredentials
-  );
-
-  // If the token is invalid try another method
-  if (!token) {
-    return undefined;
-  }
-
   // Build URL and headers for the schema request
   const schemaUrl = new URL(
     `api/collections/${options.collectionName}`,

--- a/test/schema/get-remote-schema.e2e-spec.ts
+++ b/test/schema/get-remote-schema.e2e-spec.ts
@@ -1,47 +1,57 @@
 import { assert, beforeAll, describe, expect, it } from "vitest";
 import { getRemoteSchema } from "../../src/schema/get-remote-schema";
+import { getSuperuserToken } from "../../src/utils/get-superuser-token";
 import { checkE2eConnection } from "../_mocks/check-e2e-connection";
 import { createLoaderOptions } from "../_mocks/create-loader-options";
 
 describe("getRemoteSchema", () => {
   const options = createLoaderOptions();
+  let token: string;
 
   beforeAll(async () => {
     await checkE2eConnection();
-  });
 
-  it("should return undefined if no superuser credentials are provided", async () => {
-    const result = await getRemoteSchema({
-      ...options,
-      superuserCredentials: undefined
-    });
+    const superuserToken = await getSuperuserToken(
+      options.url,
+      options.superuserCredentials!
+    );
+    assert(superuserToken, "Superuser token should not be undefined");
 
-    expect(result).toBeUndefined();
+    token = superuserToken;
   });
 
   it("should return undefined if superuser token is invalid", async () => {
-    const result = await getRemoteSchema({
-      ...options,
-      superuserCredentials: { email: "invalid", password: "invalid" }
-    });
+    const result = await getRemoteSchema(
+      {
+        ...options,
+        superuserCredentials: { email: "invalid", password: "invalid" }
+      },
+      "invalid-token"
+    );
 
     expect(result).toBeUndefined();
   });
 
   it("should return undefined if fetch request fails", async () => {
-    const result = await getRemoteSchema({
-      ...options,
-      collectionName: "invalidCollection"
-    });
+    const result = await getRemoteSchema(
+      {
+        ...options,
+        collectionName: "invalidCollection"
+      },
+      token
+    );
 
     expect(result).toBeUndefined();
   });
 
   it("should return schema if fetch request is successful", async () => {
-    const result = await getRemoteSchema({
-      ...options,
-      collectionName: "users"
-    });
+    const result = await getRemoteSchema(
+      {
+        ...options,
+        collectionName: "users"
+      },
+      token
+    );
 
     assert(result, "Schema is not defined.");
 


### PR DESCRIPTION
Instead of requesting a new superuser token for every schema generation (app start) and for every time the collection is refreshed, we can request it once on app start. Since the loader itself is not async, we hold on to the promise and wait for it to resolve (multiple times), before generating the schema / loading entries