### PR TITLE
Use impersonate token

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,14 @@
-npx lint-staged
+# Get list of staged files
+staged_files=$(git diff --cached --name-only)
+
+# Only proceed if there are staged files
+if [ -n "$staged_files" ]; then
+  # Check if any TypeScript files are staged
+  if echo "$staged_files" | grep -q "\.ts$"; then
+    echo "🔍 Running type check..."
+    npm run typecheck
+  fi
+
+  # Run lint-staged for other checks
+  npx lint-staged
+fi

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -2,6 +2,6 @@
  * @type {import('lint-staged').Configuration}
  */
 export default {
-  "!(*.ts)": "prettier --write",
+  "!(*.ts|*.ts.snap)": "prettier --write",
   "*.ts": ["eslint --fix", "prettier --write"]
 };

--- a/src/loader/cleanup-entries.ts
+++ b/src/loader/cleanup-entries.ts
@@ -56,9 +56,16 @@ export async function cleanupEntries(
     if (!collectionRequest.ok) {
       // If the collection is locked, an superuser token is required
       if (collectionRequest.status === 403) {
-        context.logger.error(
-          `The collection is not accessible without superuser rights. Please provide superuser credentials in the config.`
-        );
+        if (
+          options.superuserCredentials &&
+          "impersonateToken" in options.superuserCredentials
+        ) {
+          context.logger.error("The given impersonate token is not valid.");
+        } else {
+          context.logger.error(
+            "The collection is not accessible without superuser rights. Please provide superuser credentials in the config."
+          );
+        }
       } else {
         const reason = await collectionRequest
           .json()

--- a/src/loader/load-entries.ts
+++ b/src/loader/load-entries.ts
@@ -9,8 +9,6 @@ import { parseEntry } from "./parse-entry";
  * @param context Context of the loader.
  * @param superuserToken Superuser token to access all resources.
  * @param lastModified Date of the last fetch to only update changed entries.
- *
- * @returns `true` if the collection has an updated column, `false` otherwise.
  */
 export async function loadEntries(
   options: PocketBaseLoaderOptions,

--- a/src/loader/load-entries.ts
+++ b/src/loader/load-entries.ts
@@ -76,9 +76,16 @@ export async function loadEntries(
     if (!collectionRequest.ok) {
       // If the collection is locked, an superuser token is required
       if (collectionRequest.status === 403) {
-        throw new Error(
-          `The collection is not accessible without superuser rights. Please provide superuser credentials in the config.`
-        );
+        if (
+          options.superuserCredentials &&
+          "impersonateToken" in options.superuserCredentials
+        ) {
+          throw new Error("The given impersonate token is not valid.");
+        } else {
+          throw new Error(
+            "The collection is not accessible without superuser rights. Please provide superuser credentials in the config."
+          );
+        }
       }
 
       // Get the reason for the error

--- a/src/pocketbase-loader.ts
+++ b/src/pocketbase-loader.ts
@@ -11,11 +11,22 @@ import { getSuperuserToken } from "./utils/get-superuser-token";
  * @param options Options for the loader. See {@link PocketBaseLoaderOptions} for more details.
  */
 export function pocketbaseLoader(options: PocketBaseLoaderOptions): Loader {
-  // Get a superuser token if credentials are provided
   let tokenPromise: Promise<string | undefined>;
   if (options.superuserCredentials) {
-    tokenPromise = getSuperuserToken(options.url, options.superuserCredentials);
+    if ("impersonateToken" in options.superuserCredentials) {
+      // Impersonate token provided, so use it directly.
+      tokenPromise = Promise.resolve(
+        options.superuserCredentials.impersonateToken
+      );
+    } else {
+      // Email and password provided, so get a temporary superuser token.
+      tokenPromise = getSuperuserToken(
+        options.url,
+        options.superuserCredentials
+      );
+    }
   } else {
+    // No credentials provided, so no token can be used.
     tokenPromise = Promise.resolve(undefined);
   }
 

--- a/src/types/pocketbase-loader-options.type.ts
+++ b/src/types/pocketbase-loader-options.type.ts
@@ -58,16 +58,24 @@ export interface PocketBaseLoaderOptions {
    * Credentials of a superuser to get full access to the PocketBase instance.
    * This is required to get automatic type generation without a local schema, to access all resources even if they are not public and to fetch content of hidden fields.
    */
-  superuserCredentials?: {
-    /**
-     * Email of the superuser.
-     */
-    email: string;
-    /**
-     * Password of the superuser.
-     */
-    password: string;
-  };
+  superuserCredentials?:
+    | {
+        /**
+         * Email of the superuser.
+         */
+        email: string;
+        /**
+         * Password of the superuser.
+         */
+        password: string;
+      }
+    | {
+        /**
+         * Impersonate auth token of the superuser.
+         * This token will take precedence over the email and password.
+         */
+        impersonateToken: string;
+      };
   /**
    * File path to the local schema file.
    * This file will be used to generate the schema for the collection.

--- a/test/loader/cleanup-entries.e2e-spec.ts
+++ b/test/loader/cleanup-entries.e2e-spec.ts
@@ -32,9 +32,15 @@ describe("cleanupEntries", () => {
   beforeEach(async () => {
     context = createLoaderContext();
 
+    assert(options.superuserCredentials, "Superuser credentials are not set.");
+    assert(
+      !("impersonateToken" in options.superuserCredentials),
+      "Impersonate token should not be used in tests."
+    );
+
     const token = await getSuperuserToken(
       options.url,
-      options.superuserCredentials!
+      options.superuserCredentials
     );
 
     assert(token, "Superuser token is not available.");

--- a/test/loader/load-entries.e2e-spec.ts
+++ b/test/loader/load-entries.e2e-spec.ts
@@ -36,9 +36,15 @@ describe("loadEntries", () => {
   beforeEach(async () => {
     context = createLoaderContext();
 
+    assert(options.superuserCredentials, "Superuser credentials are not set.");
+    assert(
+      !("impersonateToken" in options.superuserCredentials),
+      "Impersonate token should not be used in tests."
+    );
+
     const token = await getSuperuserToken(
       options.url,
-      options.superuserCredentials!
+      options.superuserCredentials
     );
 
     assert(token, "Superuser token is not available.");

--- a/test/schema/generate-schema.e2e-spec.ts
+++ b/test/schema/generate-schema.e2e-spec.ts
@@ -13,9 +13,15 @@ describe("generateSchema", () => {
   beforeAll(async () => {
     await checkE2eConnection();
 
+    assert(options.superuserCredentials, "Superuser credentials are not set.");
+    assert(
+      !("impersonateToken" in options.superuserCredentials),
+      "Impersonate token should not be used in tests."
+    );
+
     const superuserToken = await getSuperuserToken(
       options.url,
-      options.superuserCredentials!
+      options.superuserCredentials
     );
     assert(superuserToken, "Superuser token should not be undefined");
 

--- a/test/schema/get-remote-schema.e2e-spec.ts
+++ b/test/schema/get-remote-schema.e2e-spec.ts
@@ -11,9 +11,15 @@ describe("getRemoteSchema", () => {
   beforeAll(async () => {
     await checkE2eConnection();
 
+    assert(options.superuserCredentials, "Superuser credentials are not set.");
+    assert(
+      !("impersonateToken" in options.superuserCredentials),
+      "Impersonate token should not be used in tests."
+    );
+
     const superuserToken = await getSuperuserToken(
       options.url,
-      options.superuserCredentials!
+      options.superuserCredentials
     );
     assert(superuserToken, "Superuser token should not be undefined");
 

--- a/test/utils/get-superuser-token.e2e-spec.ts
+++ b/test/utils/get-superuser-token.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it } from "vitest";
+import { assert, beforeAll, describe, expect, it } from "vitest";
 import { getSuperuserToken } from "../../src/utils/get-superuser-token";
 import { checkE2eConnection } from "../_mocks/check-e2e-connection";
 import { createLoaderContext } from "../_mocks/create-loader-context";
@@ -32,9 +32,15 @@ describe("getSuperuserToken", () => {
   });
 
   it("should return token if fetch request is successful", async () => {
+    assert(options.superuserCredentials, "Superuser credentials are not set.");
+    assert(
+      !("impersonateToken" in options.superuserCredentials),
+      "Impersonate token should not be used in tests."
+    );
+
     const result = await getSuperuserToken(
       options.url,
-      options.superuserCredentials!
+      options.superuserCredentials
     );
     expect(result).toBeDefined();
   });


### PR DESCRIPTION
This allows developers to specify only one impersonate token instead of superuser credentials with email and password. This makes it much safer to user the loader since these tokens have a lifetime and can be invalidated independent of an admins password. Though I still recommend some kind of technical admin account for this.