### PR TITLE
Add `fields` configuration option

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,12 +3,12 @@ staged_files=$(git diff --cached --name-only)
 
 # Only proceed if there are staged files
 if [ -n "$staged_files" ]; then
+  # Run lint-staged for other linter and format checks
+  npx lint-staged
+
   # Check if any TypeScript files are staged
   if echo "$staged_files" | grep -q "\.ts$"; then
     echo "🔍 Running type check..."
     npm run typecheck
   fi
-
-  # Run lint-staged for other checks
-  npx lint-staged
 fi

--- a/README.md
+++ b/README.md
@@ -130,6 +130,24 @@ This filter will be added to the PocketBase API request and will only fetch entr
 This is in addition to the built-in filtering of the loader, which handles the incremental builds using the `updated` field.
 For more information on how to use filters, check out the [PocketBase documentation](https://pocketbase.io/docs/api-records/#listsearch-records).
 
+### Partial data loading
+
+By default, the loader fetches all fields for each entry in your PocketBase collection.
+If you want to optimize data loading or restrict the fields available in your content collection, you can use the `fields` option.
+
+```ts
+const blog = defineCollection({
+  loader: pocketbaseLoader({
+    ...options,
+    fields: ["title", "summary", "coverImage"]
+  })
+});
+```
+
+This parameter will be added to the PocketBase API request and will only return these fields for each entry.
+Additional system fields like `id`, `collectionName` and `collectionId`, as well as any fields specified for `idField`, `updatedField` or `contentFields` will be added automatically.
+For further details on field selection, see the [PocketBase API documentation](https://pocketbase.io/docs/api-records/#listsearch-records).
+
 ## Type generation
 
 The loader can automatically generate types for your collection.

--- a/src/loader/fetch-entry.ts
+++ b/src/loader/fetch-entry.ts
@@ -1,5 +1,7 @@
 import type { PocketBaseEntry } from "../types/pocketbase-entry.type";
 import type { ExperimentalPocketBaseLiveLoaderOptions } from "../types/pocketbase-loader-options.type";
+import { combineFieldsForRequest } from "../utils/combine-fields-for-request";
+import { formatFields } from "../utils/format-fields";
 
 /**
  * Retrieves a specific entry from a PocketBase collection using its ID and loader options.
@@ -13,7 +15,14 @@ export async function fetchEntry<TEntry extends PocketBaseEntry>(
   const entryUrl = new URL(
     `api/collections/${options.collectionName}/records/${id}`,
     options.url
-  ).href;
+  );
+
+  // Add fields parameter if specified
+  const fieldsArray = formatFields(options.fields);
+  const combinedFields = combineFieldsForRequest(fieldsArray, options);
+  if (combinedFields) {
+    entryUrl.searchParams.set("fields", combinedFields.join(","));
+  }
 
   // Create the headers for the request to append the token (if available)
   const entryHeaders = new Headers();
@@ -22,7 +31,7 @@ export async function fetchEntry<TEntry extends PocketBaseEntry>(
   }
 
   // Fetch the entry from the collection
-  const entryRequest = await fetch(entryUrl, {
+  const entryRequest = await fetch(entryUrl.href, {
     headers: entryHeaders
   });
 

--- a/src/schema/generate-schema.ts
+++ b/src/schema/generate-schema.ts
@@ -69,70 +69,10 @@ export async function generateSchema(
     options.experimental?.liveTypesOnly ?? false
   );
 
-  // Check if custom id field is present
-  if (options.idField) {
-    // Find the id field in the schema
-    const idField = collection.fields.find(
-      (field) => field.name === options.idField
-    );
-
-    // Check if the id field is present and of a valid type
-    if (!idField) {
-      console.error(
-        `The id field "${options.idField}" is not present in the schema of the collection "${options.collectionName}".`
-      );
-    } else if (!VALID_ID_TYPES.includes(idField.type)) {
-      console.error(
-        `The id field "${options.idField}" for collection "${
-          options.collectionName
-        }" is of type "${
-          idField.type
-        }" which is not recommended. Please use one of the following types: ${VALID_ID_TYPES.join(
-          ", "
-        )}.`
-      );
-    }
-  }
-
-  // Check if the content field is present
-  if (
-    typeof options.contentFields === "string" &&
-    !fields[options.contentFields]
-  ) {
-    console.error(
-      `The content field "${options.contentFields}" is not present in the schema of the collection "${options.collectionName}".`
-    );
-  } else if (Array.isArray(options.contentFields)) {
-    for (const field of options.contentFields) {
-      if (!fields[field]) {
-        console.error(
-          `The content field "${field}" is not present in the schema of the collection "${options.collectionName}".`
-        );
-      }
-    }
-  }
-
-  // Check if the updated field is present
-  if (options.updatedField) {
-    if (!fields[options.updatedField]) {
-      console.error(
-        `The field "${options.updatedField}" is not present in the schema of the collection "${options.collectionName}".\nThis will lead to errors when trying to fetch only updated entries.`
-      );
-    } else {
-      const updatedField = collection.fields.find(
-        (field) => field.name === options.updatedField
-      );
-      if (
-        !updatedField ||
-        updatedField.type !== "autodate" ||
-        !updatedField.onUpdate
-      ) {
-        console.warn(
-          `The field "${options.updatedField}" is not of type "autodate" with the value "Update" or "Create/Update".\nMake sure that the field is automatically updated when the entry is updated!`
-        );
-      }
-    }
-  }
+  // Do some sanity checks on the provided options
+  checkCustomIdField(collection, options);
+  checkContentField(fields, options);
+  checkUpdatedField(fields, collection, options);
 
   // Combine the basic schema with the parsed fields
   const schema = z.object({
@@ -154,4 +94,95 @@ export async function generateSchema(
   return schema.transform((entry) =>
     transformFiles(options.url, fileFields, entry)
   );
+}
+
+/**
+ * Check if the custom id field is present
+ */
+function checkCustomIdField(
+  collection: PocketBaseCollection,
+  options: PocketBaseLoaderOptions
+): void {
+  if (!options.idField) {
+    return;
+  }
+
+  // Find the id field in the schema
+  const idField = collection.fields.find(
+    (field) => field.name === options.idField
+  );
+
+  // Check if the id field is present and of a valid type
+  if (!idField) {
+    console.error(
+      `The id field "${options.idField}" is not present in the schema of the collection "${options.collectionName}".`
+    );
+  } else if (!VALID_ID_TYPES.includes(idField.type)) {
+    console.error(
+      `The id field "${options.idField}" for collection "${
+        options.collectionName
+      }" is of type "${
+        idField.type
+      }" which is not recommended. Please use one of the following types: ${VALID_ID_TYPES.join(
+        ", "
+      )}.`
+    );
+  }
+}
+
+/**
+ * Check if the content field(s) are present
+ */
+function checkContentField(
+  fields: Record<string, z.ZodType>,
+  options: PocketBaseLoaderOptions
+): void {
+  if (
+    typeof options.contentFields === "string" &&
+    !fields[options.contentFields]
+  ) {
+    console.error(
+      `The content field "${options.contentFields}" is not present in the schema of the collection "${options.collectionName}".`
+    );
+  } else if (Array.isArray(options.contentFields)) {
+    for (const field of options.contentFields) {
+      if (!fields[field]) {
+        console.error(
+          `The content field "${field}" is not present in the schema of the collection "${options.collectionName}".`
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Check if the updated field is present
+ */
+function checkUpdatedField(
+  fields: Record<string, z.ZodType>,
+  collection: PocketBaseCollection,
+  options: PocketBaseLoaderOptions
+): void {
+  if (!options.updatedField) {
+    return;
+  }
+
+  if (!fields[options.updatedField]) {
+    console.error(
+      `The field "${options.updatedField}" is not present in the schema of the collection "${options.collectionName}".\nThis will lead to errors when trying to fetch only updated entries.`
+    );
+  } else {
+    const updatedField = collection.fields.find(
+      (field) => field.name === options.updatedField
+    );
+    if (
+      !updatedField ||
+      updatedField.type !== "autodate" ||
+      !updatedField.onUpdate
+    ) {
+      console.warn(
+        `The field "${options.updatedField}" is not of type "autodate" with the value "Update" or "Create/Update".\nMake sure that the field is automatically updated when the entry is updated!`
+      );
+    }
+  }
 }

--- a/src/types/pocketbase-loader-options.type.ts
+++ b/src/types/pocketbase-loader-options.type.ts
@@ -39,7 +39,6 @@ export interface PocketBaseLoaderOptions {
   updatedField?: string;
   /**
    * Custom filter that is applied when loading data from PocketBase.
-   * Valid syntax can be found in the [PocketBase documentation](https://pocketbase.io/docs/api-records/#listsearch-records)
    *
    * The loader will also add it's own filters for incremental builds.
    * These will be added to your custom filter query.
@@ -52,8 +51,38 @@ export interface PocketBaseLoaderOptions {
    * // request
    * `?filter=(${loaderFilter})&&(release >= @now && deleted = false)`
    * ```
+   *
+   * @see {@link https://pocketbase.io/docs/api-records/#listsearch-records PocketBase documentation} for valid syntax
    */
   filter?: string;
+  /**
+   * Specify which fields to return for each record.
+   * This can be either a comma-separated string of field names or an array of field names.
+   * Only the specified fields will be included in the response and schema.
+   *
+   * Use "*" to include all fields (same as not specifying the fields option).
+   *
+   * Note: The basic fields (`id`, `collectionId`, `collectionName`) are automatically included
+   * in API requests when using field filtering. Additionally, any custom fields specified in the
+   * loader options (`idField`, `updatedField`, `contentFields`) are also automatically included.
+   *
+   * Warning: Expand fields are not currently supported by this loader.
+   *
+   * Example:
+   * ```ts
+   * // Using string format:
+   * fields: 'title,content,author'
+   *
+   * // Using array format:
+   * fields: ['title', 'content', 'author']
+   *
+   * // Include all fields:
+   * fields: '*'
+   * ```
+   *
+   * @see {@link https://pocketbase.io/docs/api-records/#listsearch-records PocketBase documentation} for valid syntax
+   */
+  fields?: string | Array<string>;
   /**
    * Credentials of a superuser to get full access to the PocketBase instance.
    * This is required to get automatic type generation without a local schema, to access all resources even if they are not public and to fetch content of hidden fields.
@@ -126,5 +155,6 @@ export type ExperimentalPocketBaseLiveLoaderOptions = Pick<
   | "contentFields"
   | "updatedField"
   | "filter"
+  | "fields"
   | "superuserCredentials"
 >;

--- a/src/utils/combine-fields-for-request.ts
+++ b/src/utils/combine-fields-for-request.ts
@@ -1,0 +1,54 @@
+import type { PocketBaseLoaderOptions } from "../types/pocketbase-loader-options.type";
+
+/**
+ * Combine basic, special, and user-specified fields for PocketBase API requests.
+ * This utility ensures that required system fields are always included in API requests.
+ *
+ * @param userFields Array of fields specified by the user, or undefined for all fields
+ * @param options PocketBase loader options containing custom field configurations
+ * @returns Combined array of fields to include in the API request, or undefined for all fields
+ */
+export function combineFieldsForRequest(
+  userFields: Array<string> | undefined,
+  options: Pick<
+    PocketBaseLoaderOptions,
+    "idField" | "updatedField" | "contentFields"
+  >
+): Array<string> | undefined {
+  // If no fields specified, return undefined to get all fields
+  if (!userFields) {
+    return undefined;
+  }
+
+  // Basic fields that are always required by the loader
+  const basicFields = ["id", "collectionId", "collectionName"];
+
+  // Special fields that are configured in options
+  const specialFields: Array<string> = [];
+
+  // Add custom id field if specified
+  if (options.idField && options.idField !== "id") {
+    specialFields.push(options.idField);
+  }
+
+  // Add updated field if specified
+  if (options.updatedField) {
+    specialFields.push(options.updatedField);
+  }
+
+  // Add content fields if specified
+  if (options.contentFields) {
+    if (Array.isArray(options.contentFields)) {
+      specialFields.push(...options.contentFields);
+    } else {
+      specialFields.push(options.contentFields);
+    }
+  }
+
+  // Combine all field sets, removing duplicates
+  const allFields = [
+    ...new Set([...basicFields, ...specialFields, ...userFields])
+  ];
+
+  return allFields;
+}

--- a/src/utils/extract-field-names.ts
+++ b/src/utils/extract-field-names.ts
@@ -1,0 +1,15 @@
+/**
+ * Extract field names from fields that may contain modifiers like :excerpt().
+ *
+ * @param fields Array of field specifications that may contain modifiers
+ * @returns Array of clean field names suitable for schema parsing
+ */
+export function extractFieldNames(
+  fields: Array<string> | undefined
+): Array<string> | undefined {
+  if (!fields) {
+    return undefined;
+  }
+
+  return fields.map((field) => field.split(":")[0]);
+}

--- a/src/utils/format-fields.ts
+++ b/src/utils/format-fields.ts
@@ -1,0 +1,63 @@
+import type { PocketBaseLoaderOptions } from "../types/pocketbase-loader-options.type";
+
+/**
+ * Format fields option into an array and validate for expand usage.
+ * Handles wildcard "*" and preserves excerpt field modifiers.
+ *
+ * @param fields The fields option (string or array)
+ * @returns Formatted fields array, or undefined if no fields specified or "*" wildcard is used
+ */
+export function formatFields(
+  fields: PocketBaseLoaderOptions["fields"]
+): Array<string> | undefined {
+  if (!fields || fields.length === 0) {
+    return undefined;
+  }
+
+  let fieldList: Array<string>;
+  if (Array.isArray(fields)) {
+    fieldList = fields.map((f) => f.trim());
+  } else {
+    // Split carefully, respecting parentheses in excerpt syntax
+    fieldList = splitFieldsString(fields).map((f) => f.trim());
+  }
+
+  // Warn if expand is used since it's not currently supported
+  const hasExpand = fieldList.some((field) => field.includes("expand"));
+  if (hasExpand) {
+    console.warn(
+      'The "expand" parameter is not currently supported by astro-loader-pocketbase and will be filtered out.'
+    );
+    fieldList = fieldList.filter((field) => !field.includes("expand"));
+  }
+
+  // Check for "*" wildcard - if found anywhere, include all fields
+  const hasWildcard = fieldList.some((field) => field === "*");
+  if (hasWildcard) {
+    return undefined;
+  }
+
+  return fieldList;
+}
+
+/**
+ * Splits the fields string at `,` but respects the `:excerpt(number, boolean)` option
+ */
+function splitFieldsString(fieldsString: string): Array<string> {
+  // First, split by comma
+  const initialSplit = fieldsString.split(",");
+
+  const fields: Array<string> = [];
+  for (let i = 0; i < initialSplit.length; i++) {
+    const part = initialSplit[i];
+
+    if (part.includes("(") && !part.includes(")")) {
+      fields.push(`${part},${initialSplit[++i]}`);
+      continue;
+    }
+
+    fields.push(part);
+  }
+
+  return fields;
+}

--- a/test/loader/fetch-entry.e2e-spec.ts
+++ b/test/loader/fetch-entry.e2e-spec.ts
@@ -167,4 +167,81 @@ describe("fetchEntry", () => {
       await deleteCollection(testOptions, superuserToken);
     });
   });
+
+  describe("fields filtering", () => {
+    test("should include fields parameter in request when fields option is provided", async () => {
+      const testOptions = {
+        ...options,
+        collectionName: randomUUID().replaceAll("-", ""),
+        fields: ["title", "content"]
+      };
+
+      await insertCollection(
+        [
+          { name: "title", type: "text" },
+          { name: "content", type: "text" },
+          { name: "description", type: "text" }
+        ],
+        testOptions,
+        superuserToken
+      );
+
+      const entry = await insertEntry(
+        {
+          title: "Test Title",
+          content: "Test Content",
+          description: "Test Description"
+        },
+        testOptions,
+        superuserToken
+      );
+
+      const result = await fetchEntry<PocketBaseEntry>(
+        entry.id,
+        testOptions,
+        superuserToken
+      );
+
+      // Description should not be included
+      delete entry["description"];
+      expect(result).toEqual(entry);
+
+      await deleteCollection(testOptions, superuserToken);
+    });
+
+    test("should include all fields when no fields option is provided", async () => {
+      const testOptions = {
+        ...options,
+        collectionName: randomUUID().replaceAll("-", "")
+      };
+
+      await insertCollection(
+        [
+          { name: "title", type: "text" },
+          { name: "content", type: "text" }
+        ],
+        testOptions,
+        superuserToken
+      );
+
+      const entry = await insertEntry(
+        {
+          title: "Test Title",
+          content: "Test Content"
+        },
+        testOptions,
+        superuserToken
+      );
+
+      const result = await fetchEntry<PocketBaseEntry>(
+        entry.id,
+        testOptions,
+        superuserToken
+      );
+
+      expect(result).toEqual(entry);
+
+      await deleteCollection(testOptions, superuserToken);
+    });
+  });
 });

--- a/test/schema/parse-schema.spec.ts
+++ b/test/schema/parse-schema.spec.ts
@@ -12,7 +12,10 @@ describe("parseSchema", () => {
         fields: [{ name: "age", type: "number", required: true, hidden: false }]
       };
 
-      const schema = parseSchema(collection, undefined, false, false);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false
+      });
 
       const valid = {
         age: 42
@@ -32,7 +35,10 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false
+      });
 
       const valid = {
         age: 42
@@ -51,7 +57,10 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, true);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: true
+      });
 
       const valid = {
         age: 42
@@ -72,7 +81,10 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false
+      });
 
       const valid = {
         isAdult: true
@@ -92,7 +104,10 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false
+      });
 
       const valid = {
         isAdult: true
@@ -111,7 +126,10 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, true);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: true
+      });
 
       const valid = {
         isAdult: true
@@ -132,7 +150,10 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false
+      });
 
       const valid = {
         birthday: new Date()
@@ -154,7 +175,10 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false
+      });
 
       const valid = {
         birthday: new Date()
@@ -180,7 +204,10 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false
+      });
 
       const valid = {
         birthday: new Date()
@@ -207,7 +234,10 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false
+      });
 
       const valid = {
         birthday: new Date()
@@ -232,7 +262,10 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false
+      });
 
       const valid = {
         birthday: new Date()
@@ -258,7 +291,10 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false
+      });
 
       const valid = {
         coordinates: { lon: 12.34, lat: 56.78 }
@@ -286,7 +322,10 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false
+      });
 
       const valid = {
         coordinates: { lon: 12.34, lat: 56.78 }
@@ -313,7 +352,10 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false
+      });
 
       const valid = {
         status: "active"
@@ -338,7 +380,12 @@ describe("parseSchema", () => {
         ]
       };
 
-      expect(() => parseSchema(collection, undefined, false, false)).toThrow();
+      expect(() =>
+        parseSchema(collection, undefined, {
+          hasSuperuserRights: false,
+          improveTypes: false
+        })
+      ).toThrow();
     });
 
     test("should parse select fields with multiple values correctly", () => {
@@ -357,7 +404,10 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false
+      });
 
       const valid = {
         status: ["active", "inactive"]
@@ -385,7 +435,10 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false
+      });
 
       const valid = {
         status: "active"
@@ -412,7 +465,10 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false
+      });
 
       const valid = {
         user: "123"
@@ -438,7 +494,10 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false
+      });
 
       const valid = {
         user: ["123", "456"]
@@ -463,7 +522,10 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false
+      });
 
       const valid = {
         user: "123"
@@ -490,7 +552,10 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false
+      });
 
       const valid = {
         avatar: "https://example.com/avatar.jpg"
@@ -516,7 +581,10 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false
+      });
 
       const valid = {
         avatar: [
@@ -548,7 +616,10 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false
+      });
 
       const valid = {
         avatar: "https://example.com/avatar.jpg"
@@ -582,7 +653,10 @@ describe("parseSchema", () => {
         })
       };
 
-      const schema = parseSchema(collection, customSchemas, false, false);
+      const schema = parseSchema(collection, customSchemas, {
+        hasSuperuserRights: false,
+        improveTypes: false
+      });
 
       const valid = {
         settings: {
@@ -613,7 +687,10 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false
+      });
 
       const valid = {
         settings: {
@@ -643,7 +720,10 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false
+      });
 
       const valid = {
         settings: {
@@ -665,7 +745,10 @@ describe("parseSchema", () => {
         fields: [{ name: "name", type: "text", required: true, hidden: false }]
       };
 
-      const schema = parseSchema(collection, undefined, false, false);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false
+      });
 
       const valid = {
         name: "John Doe"
@@ -683,7 +766,10 @@ describe("parseSchema", () => {
         fields: [{ name: "name", type: "text", required: false, hidden: false }]
       };
 
-      const schema = parseSchema(collection, undefined, false, false);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false
+      });
 
       const valid = {
         name: "John Doe"
@@ -704,7 +790,11 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false, true);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false,
+        experimentalLiveTypesOnly: true
+      });
 
       const valid = {
         birthday: "2023-12-01T10:00:00Z"
@@ -723,7 +813,11 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false, true);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false,
+        experimentalLiveTypesOnly: true
+      });
 
       const valid = {
         created: "2023-12-01T10:00:00Z"
@@ -742,7 +836,11 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false, false);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false,
+        experimentalLiveTypesOnly: false
+      });
 
       const valid = {
         birthday: new Date()
@@ -763,7 +861,10 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false
+      });
 
       const valid = {
         birthday: new Date()
@@ -787,7 +888,11 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false, true);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false,
+        experimentalLiveTypesOnly: true
+      });
 
       const valid = {
         title: "Test Title",
@@ -824,7 +929,11 @@ describe("parseSchema", () => {
         ]
       };
 
-      const schema = parseSchema(collection, undefined, false, false, true);
+      const schema = parseSchema(collection, undefined, {
+        hasSuperuserRights: false,
+        improveTypes: false,
+        experimentalLiveTypesOnly: true
+      });
 
       const validWithDate = {
         birthday: "2023-12-01T10:00:00Z"

--- a/test/utils/combine-fields-for-request.spec.ts
+++ b/test/utils/combine-fields-for-request.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { combineFieldsForRequest } from "../../src/utils/combine-fields-for-request";
+
+const SYSTEM_FIELDS = ["id", "collectionId", "collectionName"];
+
+describe("combineFieldsForRequest", () => {
+  describe("when no user fields are provided", () => {
+    it("should return undefined for undefined input", () => {
+      const result = combineFieldsForRequest(undefined, {});
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("when user fields are provided", () => {
+    it("should combine basic and user fields without hardcoded special fields", () => {
+      const userFields = ["title", "content"];
+      const result = combineFieldsForRequest(userFields, {});
+
+      expect(result).toEqual(expect.arrayContaining(SYSTEM_FIELDS));
+      expect(result).toEqual(expect.arrayContaining(userFields));
+      expect(result).length(SYSTEM_FIELDS.length + userFields.length);
+    });
+
+    it("should include custom option fields when specified", () => {
+      const userFields = ["title", "content"];
+      const options = {
+        idField: "custom_id",
+        updatedField: "modified_at",
+        contentFields: ["description", "body"]
+      };
+      const result = combineFieldsForRequest(userFields, options);
+
+      expect(result).toEqual(expect.arrayContaining(SYSTEM_FIELDS));
+      expect(result).toEqual(expect.arrayContaining(userFields));
+      expect(result).toEqual(
+        expect.arrayContaining([
+          options.idField,
+          options.updatedField,
+          ...options.contentFields
+        ])
+      );
+      expect(result).length(SYSTEM_FIELDS.length + userFields.length + 4);
+    });
+
+    it("should handle single content field as string", () => {
+      const userFields = ["title"];
+      const options = {
+        contentFields: "content"
+      };
+      const result = combineFieldsForRequest(userFields, options);
+
+      expect(result).toEqual(expect.arrayContaining(SYSTEM_FIELDS));
+      expect(result).toEqual(expect.arrayContaining(userFields));
+      expect(result).toEqual(expect.arrayContaining([options.contentFields]));
+      expect(result).length(SYSTEM_FIELDS.length + userFields.length + 1);
+    });
+  });
+});

--- a/test/utils/extract-field-names.spec.ts
+++ b/test/utils/extract-field-names.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { extractFieldNames } from "../../src/utils/extract-field-names";
+
+describe("extractFieldNames", () => {
+  it("should return undefined for undefined input", () => {
+    const result = extractFieldNames(undefined);
+    expect(result).toBeUndefined();
+  });
+
+  it("should return the same field names without modifiers", () => {
+    const fields = ["title", "content", "author"];
+    const result = extractFieldNames(fields);
+
+    expect(result).toEqual(["title", "content", "author"]);
+  });
+
+  it("should extract field names with excerpt modifiers", () => {
+    const fields = [
+      "description:excerpt(100)",
+      "body:excerpt(500,false)",
+      "summary"
+    ];
+    const result = extractFieldNames(fields);
+
+    expect(result).toEqual(["description", "body", "summary"]);
+  });
+});

--- a/test/utils/format-fields.spec.ts
+++ b/test/utils/format-fields.spec.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import { formatFields } from "../../src/utils/format-fields";
+
+describe("formatFields", () => {
+  describe("when no fields are provided", () => {
+    it("should return undefined for undefined input", () => {
+      const result = formatFields(undefined);
+      expect(result).toBeUndefined();
+    });
+
+    it("should handle empty string", () => {
+      const result = formatFields("");
+      expect(result).toBeUndefined();
+    });
+
+    it("should handle empty array", () => {
+      const result = formatFields([]);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("when fields are provided as a string", () => {
+    it("should return an array for simple fields", () => {
+      const result = formatFields("title,content,author");
+      expect(result).toEqual(["title", "content", "author"]);
+    });
+
+    it("should return an array for a single field", () => {
+      const result = formatFields("title");
+      expect(result).toEqual(["title"]);
+    });
+
+    it("should return undefined for the * wildcard", () => {
+      const result = formatFields("*");
+      expect(result).toBeUndefined();
+    });
+
+    it("should return undefined when * wildcard is mixed with other fields", () => {
+      const result = formatFields("title,*,content");
+      expect(result).toBeUndefined();
+    });
+
+    it("should trim whitespace from fields", () => {
+      const result = formatFields(" title , content , author ");
+      expect(result).toEqual(["title", "content", "author"]);
+    });
+  });
+
+  describe("when fields are provided as an array", () => {
+    it("should return undefined when * wildcard is in array", () => {
+      const result = formatFields(["title", "*", "content"]);
+      expect(result).toBeUndefined();
+    });
+
+    it("should trim whitespace from array fields", () => {
+      const result = formatFields([" title ", " content ", " author "]);
+      expect(result).toEqual(["title", "content", "author"]);
+    });
+  });
+
+  describe("when expand is used", () => {
+    it("should warn and filter when expand is in string fields", () => {
+      const consoleWarnSpy = vi.spyOn(console, "warn");
+
+      const result = formatFields("title,expand,content");
+
+      expect(result).toEqual(["title", "content"]);
+      expect(consoleWarnSpy).toHaveBeenCalledOnce();
+    });
+
+    it("should warn and filter when expand is in array fields", () => {
+      const consoleWarnSpy = vi.spyOn(console, "warn");
+
+      const result = formatFields(["title", "expand", "content"]);
+
+      expect(result).toEqual(["title", "content"]);
+      expect(consoleWarnSpy).toHaveBeenCalledOnce();
+    });
+
+    it("should warn when expand with dot notation is used", () => {
+      const consoleWarnSpy = vi.spyOn(console, "warn");
+
+      const result = formatFields("title,expand.user,content");
+
+      expect(result).toEqual(["title", "content"]);
+      expect(consoleWarnSpy).toHaveBeenCalledOnce();
+    });
+
+    it("should warn with mixed wildcard and expand but return undefined for wildcard", () => {
+      const consoleWarnSpy = vi.spyOn(console, "warn");
+
+      const result = formatFields("*,expand.field");
+
+      expect(result).toBeUndefined();
+      expect(consoleWarnSpy).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("when excerpt fields are used", () => {
+    it("should preserve valid excerpt field syntax", () => {
+      const result = formatFields(
+        "title,description:excerpt(200,true),content"
+      );
+
+      expect(result).toEqual([
+        "title",
+        "description:excerpt(200,true)",
+        "content"
+      ]);
+    });
+
+    it("should preserve excerpt field with just maxLength", () => {
+      const result = formatFields("title,content:excerpt(150)");
+
+      expect(result).toEqual(["title", "content:excerpt(150)"]);
+    });
+  });
+});


### PR DESCRIPTION
## Changes

**Summary:**
Adds support for the `fields` configuration option. This allows the loader to only load partial entries with a subset of data or using the `excerpt` modifier for long content that should be truncated directly by PocketBase.

_Originally implemented in: #53_

## Issues

**Related issues:**

- Related to #55

## Testing

**How to test:**

1. Steps to test the changes
2. Expected behavior
3. Any specific scenarios to verify

**Test coverage:**

- [x] Manual testing completed
- [x] Automated tests added/updated

## Code Quality

**Code review checklist:**

- [x] Code follows existing patterns and conventions
- [x] Functions are small and focused
- [x] Types are properly defined
- [x] Error handling is appropriate
- [x] Documentation is updated if needed

## Breaking Changes

**Are there any breaking changes?**

- [x] No breaking changes
- [ ] Yes, breaking changes (describe below)
